### PR TITLE
add go-tuf client binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ html/
 dist/
 .python-version
 build
+clients/go-tuf/go-tuf


### PR DESCRIPTION
To avoid getting binaries into the source tree.