### PR TITLE
Add first unit tests for repository logic

### DIFF
--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -142,18 +142,7 @@ def test_simple_signing(client: ClientRunner,
     repo.add_key_to_role(Snapshot.type)
     repo.add_key_to_role(Snapshot.type)
 
-    # Sanity-check. TODO: Make unit test outside
-    # of conformance test for this
-    repo_root = repo.load_metadata(Root.type)
-    assert repo._version_equals(Root.type, 1)
-
     repo.bump_root_by_one()
-
-    # Sanity-check. TODO: Make unit test outside
-    # of conformance test for this
-    repo_root = repo.load_metadata(Root.type)
-    assert repo._version_equals(Root.type, 2)
-    assert len(repo_root.signed.roles["snapshot"].keyids) == 4
 
     repo.update_timestamp()
     repo.update_snapshot()
@@ -228,10 +217,12 @@ def test_duplicate_keys_root(client: ClientRunner,
                                        Targets.type])
     assert client._version_equals(Snapshot.type, 1)
 
-    # Add the same signature to Snapshot 9 times
+    # Add the same signature to Snapshot 9 times in the repository
     repo.add_one_role_key_n_times_to_root(Snapshot.type, 9)
     repo.bump_root_by_one()
-    assert len(repo.root.roles["snapshot"].keyids) == 10
+    ss_obj = json.loads(repo.md_root_json)
+    assert len(ss_obj["signed"]["roles"]["snapshot"]["keyids"]) == 10
+    
     repo.update_timestamp()
     repo.update_snapshot()
 
@@ -259,10 +250,10 @@ def test_duplicate_keys_root(client: ClientRunner,
     md_snapshot = Metadata.from_file(
         os.path.join(client.metadata_dir, "snapshot.json"))
 
-    # TODO: Double check that "2" is correct here:
-    assert len(md_root.roles[Snapshot.type].keyids) == 2
-    # TODO: Double check that "2" is correct here:
-    assert len(md_snapshot.signatures) == 2
+    # TODO: Double check that "1" is correct here:
+    assert len(md_root.roles[Snapshot.type].keyids) == 1
+    # TODO: Double check that "1" is correct here:
+    assert len(md_snapshot.signatures) == 1
 
 def test_TestTimestampEqVersionsCheck(client: ClientRunner, server: SimulatorServer) -> None:
     #https://github.com/theupdateframework/go-tuf/blob/f1d8916f08e4dd25f91e40139137edb8bf0498f3/metadata/updater/updater_top_level_update_test.go#L1058

--- a/tuf_conformance/test_repository_simulator.py
+++ b/tuf_conformance/test_repository_simulator.py
@@ -1,0 +1,135 @@
+import json
+import unittest
+from tuf_conformance.repository_simulator import RepositorySimulator
+from tuf.api.metadata import (
+    Timestamp, Snapshot, Root, Targets, Metadata
+)
+from tuf_conformance.utils import meta_dict_to_bytes
+from securesystemslib.signer import CryptoSigner, Signer
+
+from tuf.api.metadata import (
+    TOP_LEVEL_ROLE_NAMES
+)
+
+class TestRepositorySimulator(unittest.TestCase):
+    """Tests that ensure the repository behaves as intended"""
+
+    def test_metadata_files_exist_after_creating_repository(self):
+        repo = RepositorySimulator()
+        self.assertTrue(repo._version_equals(Root.type, 1))
+        self.assertTrue(repo._version_equals(Snapshot.type, 1))
+        self.assertTrue(repo._version_equals(Targets.type, 1))
+        self.assertTrue(repo._version_equals(Timestamp.type, 1))
+
+    def test_add_key_to_role(self):
+        repo = RepositorySimulator()
+        # Add signature to Snapshot
+        repo.add_key_to_role(Snapshot.type)
+        repo.add_key_to_role(Snapshot.type)
+        repo.add_key_to_role(Snapshot.type)
+
+        self.assertTrue(repo._version_equals(Root.type, 1))
+
+        repo.bump_root_by_one()
+
+        repo_root = repo.load_metadata(Root.type)
+        self.assertTrue(repo._version_equals(Root.type, 2))
+        self.assertEqual(len(repo_root.signed.roles["snapshot"].keyids), 4)
+
+    def test_add_one_role_key_n_times_to_root(self):
+        repo = RepositorySimulator()
+        # Add signature to Snapshot
+        repo.add_one_role_key_n_times_to_root(Snapshot.type, 9)
+
+        repo.bump_root_by_one()
+
+        repo_root = json.loads(repo.load_metadata_bytes(Root.type))
+        root_key_ids = repo_root["signed"]["roles"]["snapshot"]["keyids"]
+        self.assertEqual(len(root_key_ids), 10)
+
+        # the last 9 ids should be identical
+        self.assertEqual(root_key_ids[1], root_key_ids[2])
+        self.assertEqual(root_key_ids[1], root_key_ids[3])
+        self.assertEqual(root_key_ids[1], root_key_ids[4])
+        self.assertEqual(root_key_ids[1], root_key_ids[5])
+        self.assertEqual(root_key_ids[1], root_key_ids[6])
+        self.assertEqual(root_key_ids[1], root_key_ids[7])
+        self.assertEqual(root_key_ids[1], root_key_ids[8])
+        self.assertEqual(root_key_ids[1], root_key_ids[9])
+
+    def test_serialize_after_signing(self):
+        repo = RepositorySimulator()
+        repo.add_one_role_key_n_times_to_root(Snapshot.type, 1)
+        repo_root = json.loads(repo.load_metadata_bytes(Root.type))
+        root_key_ids = repo_root["signed"]["roles"]["snapshot"]["keyids"]
+        self.assertEqual(len(root_key_ids), 2)
+
+        repo.bump_root_by_one()
+
+        root_md = Metadata.from_bytes(repo.md_root_json)
+        serialized_root_md = meta_dict_to_bytes(root_md.to_dict())
+        self.assertEqual(repo.md_root_json, serialized_root_md)
+
+        snapshot_md = Metadata.from_bytes(repo.md_snapshot_json)
+        serialized_snapshot_md = meta_dict_to_bytes(snapshot_md.to_dict())
+        self.assertEqual(repo.md_snapshot_json, serialized_snapshot_md)
+
+        # Test that we can add more keys
+        repo.add_one_role_key_n_times_to_root(Snapshot.type, 2)
+        repo.bump_root_by_one()
+        repo_root = json.loads(repo.load_metadata_bytes(Root.type))
+        root_key_ids = repo_root["signed"]["roles"]["snapshot"]["keyids"]
+        self.assertEqual(len(root_key_ids), 4)
+
+    def test_root_version_after_adding_same_keys(self):
+        repo = RepositorySimulator()
+        repo.add_one_role_key_n_times_to_root(Snapshot.type, 3)
+        repo_root = json.loads(repo.load_metadata_bytes(Root.type))
+        self.assertEqual(repo_root["signed"]["version"], 1)
+        repo.bump_root_by_one()
+        repo_root = json.loads(repo.load_metadata_bytes(Root.type))
+        self.assertEqual(repo_root["signed"]["version"], 2)
+        repo.bump_root_by_one()
+
+    def test_add_key_implementation(self):
+        """Tests the repositorys add_key implementation.
+        Specifically that the 'signed' bytes are equal between
+        our own implementation of add_key and the 'correct' one.
+        The test imitates the repositorys initialization method
+        with fresh but also signs the metadata using the Metadata
+        class."""
+        repo = RepositorySimulator()
+
+        repo.md_targets = Metadata(Targets(expires=repo.safe_expiry))
+        repo.md_snapshot = Metadata(Snapshot(expires=repo.safe_expiry))
+        repo.md_timestamp = Metadata(Timestamp(expires=repo.safe_expiry))
+        repo.md_root = Metadata(Root(expires=repo.safe_expiry))
+
+        repo.md_targets_json = meta_dict_to_bytes(repo.md_targets.to_dict()) 
+        repo.md_snapshot_json = meta_dict_to_bytes(repo.md_snapshot.to_dict()) 
+        repo.md_timestamp_json = meta_dict_to_bytes(repo.md_timestamp.to_dict()) 
+        repo.md_root_json = meta_dict_to_bytes(repo.md_root.to_dict()) 
+
+        for role in TOP_LEVEL_ROLE_NAMES:
+            signer = CryptoSigner.generate_ecdsa()
+
+            # Add key for role
+            # This is the test suites way to add a key.
+            repo.add_key(Root.type, role, signer)
+
+            # This is the correct way to add a key. The conf test suite
+            # does not use this method, so we use this as the correct value
+            # that we should match.
+            repo.md_root.signed.add_key(signer.public_key, role)
+
+            # Add signer for role
+            repo.add_signer(role, signer)
+
+        repo.publish_root()
+
+        our_own_bytes = meta_dict_to_bytes(json.loads(repo.load_metadata_bytes(Root.type))["signed"])
+        expected_bytes = meta_dict_to_bytes(json.loads(repo.md_root.to_bytes())["signed"])
+        self.assertEqual(our_own_bytes, expected_bytes)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tuf_conformance/utils.py
+++ b/tuf_conformance/utils.py
@@ -175,7 +175,10 @@ def get_date_n_days_in_future(days: int) -> datetime.datetime:
 
 def meta_dict_to_bytes(md: dict) -> bytes:
     """Converts a dict to bytes typically to save metadata as bytes."""
-    return json.dumps(md, indent=1).encode("utf-8")
+    return json.dumps(md,
+                      indent=None,
+                      separators = (",", ":"),
+                      sort_keys=True).encode("utf-8")
 
 class TestServerProcess:
     """Helper class used to create a child process with the subprocess.Popen


### PR DESCRIPTION
Adds the first unit tests for the repository logic. This tests the repository for correct behavior. The PR includes 6 tests.

While writing the tests, I found a few things to fix; this PR includes these fixes.