### PR TITLE
action: Fix the test path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ runs:
       id: sigstore-conformance
       env:
         ENTRYPOINT: ${{ inputs.entrypoint }}
+        TEST_LOCATION: ${{ github.action_path }}/tuf_conformance
       run: |
-        pytest tuf_conformance --entrypoint "$ENTRYPOINT"
+        pytest "$TEST_LOCATION" --entrypoint "$ENTRYPOINT"
       shell: bash


### PR DESCRIPTION
When the action is used from an external project, the test path (_tuf_conformance_) is not in working dir: prefix the the test path with action location

Fixes #49 