### PR TITLE
Add two tests for custom fields

### DIFF
--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -259,6 +259,8 @@ class RepositorySimulator():
         # update repo metadata
         self.save_metadata_bytes(role, new_ss_bytes)
         md_bytes = self.load_metadata_bytes(role)
+
+        # Verify the json is valid
         ss_obj = json.loads(md_bytes)
 
     def add_key(self, delegator: str, role: str, signer: Signer) -> None:


### PR DESCRIPTION
@jku Could you check `test_custom_field_in_meta` for correctness? Essentially, this test bumps the repo metadata so the client should update. It then adds a custom field to `TimestampMetadata["signed"]["meta"]["snapshot.json"]`: `["hash"] = "custom_field_value"`. Then the client updates and the test expects that the update should fail because there are no signatures that will verify `TimestampMetadata["signed"]`. 

My main concerns are:
1. Is `TimestampMetadata["signed"]["meta"]["snapshot.json"]["hash"]` a valid custom field according to the TUF specification? 
2. Should the client include `TimestampMetadata["signed"]["meta"]["snapshot.json"]["hash"]` when verifying keys?
3. Should the client store `TimestampMetadata["signed"]["meta"]["snapshot.json"]["hash"]` in its local metadata?

Right now the test fails at this assertion:

```python
    with open(os.path.join(client.metadata_dir, "timestamp.json"), "r") as client_timestamp_json:
        print("client timestamp: ", client_timestamp_json)
        assert json.load(client_timestamp_json)[0]["signed"]["meta"]["snapshot.json"]["hash"] == "custom_field_value"
```

... and when checking the local snapshot and timestamp version. The client bumps to version 2 for both and the test expects that it doesn't.

```python
    assert client._version_equals(Root.type, 2)
    assert client._version_equals(Snapshot.type, 1)
    assert client._version_equals(Timestamp.type, 1)
```