### PR TITLE
simplify test setup

### DIFF
--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -18,7 +18,7 @@ class ClientRunner:
     conforms to the test script definition.
 
     ClientRunner manages client resources (like the cache paths etc)"""
-    def __init__(self, client_cmd: str, server: SimulatorServer) -> None:
+    def __init__(self, client_cmd: str, server: SimulatorServer, test_name: str) -> None:
         self._server = server
         self._cmd = client_cmd
         self._tempdir = TemporaryDirectory()
@@ -28,6 +28,7 @@ class ClientRunner:
         self.metadata_dir = os.path.join(self._tempdir.name, "metadata")
         os.mkdir(self.metadata_dir)
         self.max_root_rotations = 32
+        self.test_name = test_name
 
     def get_last_downloaded_target(self) -> str:
         list_of_files = glob.glob(self._target_dir.name+"/*")

--- a/tuf_conformance/conftest.py
+++ b/tuf_conformance/conftest.py
@@ -32,7 +32,7 @@ def server():
     server.server_close()
 
 @pytest.fixture
-def client(pytestconfig, server):
+def client(pytestconfig, server, request):
     """
     Parametrize each test with the client under test.
     """
@@ -40,7 +40,7 @@ def client(pytestconfig, server):
     if not os.path.isabs(entrypoint):
         entrypoint = os.path.join(pytestconfig.invocation_params.dir, entrypoint)
 
-    return ClientRunner(entrypoint, server)
+    return ClientRunner(entrypoint, server, request.node.originalname)
 
 
 @pytest.fixture(autouse=True)

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -54,8 +54,17 @@ class SimulatorServer(ThreadingHTTPServer):
         # key is test name, value is the repository sim for that test
         self.repos: Dict[str, RepositorySimulator] = {}
 
-    def get_client_init_data(self, repo: str) -> ClientInitData:
-        return ClientInitData(
-            f"http://{self.server_address[0]}:{self.server_address[1]}/{repo}/metadata/",
-            self.repos[repo].fetch_metadata("root", 1)
+    def new_test(self, name: str) -> tuple[ClientInitData, RepositorySimulator]:
+        """Return a tuple of
+        * A new repository simulator (for test case to control)
+        * client initialization parameters (so client can find the simulated repo)
+        """
+        repo = RepositorySimulator()
+        self.repos[name] = repo
+
+        client_data = ClientInitData(
+            f"http://{self.server_address[0]}:{self.server_address[1]}/{name}/metadata/",
+            repo.fetch_metadata("root", 1)
         )
+
+        return client_data, repo

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -1,6 +1,8 @@
 # Test runner
 import os
 
+from pytest import FixtureRequest
+
 from tuf_conformance.repository_simulator import RepositorySimulator
 from tuf_conformance.simulator_server import SimulatorServer
 from tuf_conformance.client_runner import ClientRunner
@@ -10,15 +12,12 @@ from tuf.api.metadata import (
 )
 
 
-def test_TestTimestampEqVersionsCheck(client: ClientRunner,
-                                      server: SimulatorServer) -> None:
+def test_TestTimestampEqVersionsCheck(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     # https://github.com/theupdateframework/go-tuf/blob/f1d8916f08e4dd25f91e40139137edb8bf0498f3/metadata/updater/updater_top_level_update_test.go#L1058
-    name = "test_TestTimestampEqVersionsCheck"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     # Sanity check
@@ -37,17 +36,13 @@ def test_TestTimestampEqVersionsCheck(client: ClientRunner,
     assert client._version(Timestamp.type) == initial_timestamp_meta_ver
 
 
-def test_max_root_rotations(client: ClientRunner,
-                            server: SimulatorServer) -> None:
+def test_max_root_rotations(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     # Root must stop looking for new versions after Y number of
     # intermediate files were downloaded.
+    init_data, repo = server.new_test(request.node.originalname)
 
-    name = "test_max_root_rotations"
-
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     # Sanity check
@@ -85,15 +80,12 @@ def test_max_root_rotations(client: ClientRunner,
     assert client._version(Root.type) == initial_root_version+3
 
 
-def test_new_targets_hash_mismatch(client: ClientRunner,
-                                   server: SimulatorServer) -> None:
+def test_new_targets_hash_mismatch(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     # Check against snapshot role's targets hashes
-    name = "test_new_targets_hash_mismatch"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     # Sanity check
@@ -119,15 +111,12 @@ def test_new_targets_hash_mismatch(client: ClientRunner,
     assert client._version(Targets.type) == 1
 
 
-def test_new_targets_version_mismatch(client: ClientRunner,
-                                      server: SimulatorServer) -> None:
+def test_new_targets_version_mismatch(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     # Check against snapshot role's targets version
-    name = "test_new_targets_version_mismatch"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     assert client._files_exist([Root.type,
@@ -144,17 +133,10 @@ def test_new_targets_version_mismatch(client: ClientRunner,
                                 Targets.type])
 
 
-def test_basic_init_and_refresh(client: ClientRunner,
-                                server: SimulatorServer) -> None:
-    """This is an example of a test method:
-    it should likely be a e.g. a unittest.TestCase"""
-
-    name = "test_init"
-
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
+def test_basic_init_and_refresh(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
+    init_data, repo = server.new_test(request.node.originalname)
 
     # Run the test: step 1:  initialize client
     # TODO verify success?
@@ -176,16 +158,13 @@ def test_basic_init_and_refresh(client: ClientRunner,
     # TODO verify that local metadata cache has the files we expect
 
 
-def test_timestamp_eq_versions_check(client: ClientRunner,
-                                     server: SimulatorServer) -> None:
+def test_timestamp_eq_versions_check(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     # Test that a modified timestamp with different content, but the same
     # version doesn't replace the valid locally stored one.
-    name = "test_timestamp_eq_versions_check"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
 
     # Make a successful update of valid metadata which stores it in cache

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -1,8 +1,6 @@
 # Test runner
 import os
 
-from pytest import FixtureRequest
-
 from tuf_conformance.repository_simulator import RepositorySimulator
 from tuf_conformance.simulator_server import SimulatorServer
 from tuf_conformance.client_runner import ClientRunner
@@ -13,10 +11,10 @@ from tuf.api.metadata import (
 
 
 def test_TestTimestampEqVersionsCheck(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # https://github.com/theupdateframework/go-tuf/blob/f1d8916f08e4dd25f91e40139137edb8bf0498f3/metadata/updater/updater_top_level_update_test.go#L1058
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -37,11 +35,11 @@ def test_TestTimestampEqVersionsCheck(
 
 
 def test_max_root_rotations(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Root must stop looking for new versions after Y number of
     # intermediate files were downloaded.
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -81,10 +79,10 @@ def test_max_root_rotations(
 
 
 def test_new_targets_hash_mismatch(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Check against snapshot role's targets hashes
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -112,10 +110,10 @@ def test_new_targets_hash_mismatch(
 
 
 def test_new_targets_version_mismatch(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Check against snapshot role's targets version
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -134,9 +132,9 @@ def test_new_targets_version_mismatch(
 
 
 def test_basic_init_and_refresh(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     # Run the test: step 1:  initialize client
     # TODO verify success?
@@ -159,11 +157,11 @@ def test_basic_init_and_refresh(
 
 
 def test_timestamp_eq_versions_check(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Test that a modified timestamp with different content, but the same
     # version doesn't replace the valid locally stored one.
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
 

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 from datetime import timezone
-from pytest import FixtureRequest
 from tuf.api.metadata import (
     Timestamp, Snapshot, Root, Targets, Metadata,
     DelegatedRole
@@ -13,12 +12,12 @@ from tuf_conformance import utils
 
 
 def test_root_expired(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """Tests a case where root is expired. The spec (5.3.10)
     says that the root should update, so at the end, this
     test asserts that root updates but no other metadata does"""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -40,12 +39,12 @@ def test_root_expired(
 
 
 def test_snapshot_expired(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """Tests a case where the snapshot metadata is expired.
     Checks whether the clients updates the snapshot metadata
     if the repo has a newer version, but it is expired"""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -67,12 +66,12 @@ def test_snapshot_expired(
 
 
 def test_targets_expired(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """Tests a case where the targets metadata is expired.
     Checks whether the clients updates the targets metadata
     if the repo has a newer version, but it is expired"""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -97,7 +96,7 @@ def test_targets_expired(
 
 
 def test_expired_metadata(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """Verifies that expired local timestamp/snapshot can be used for
     updating from remote.
@@ -109,7 +108,7 @@ def test_expired_metadata(
      - Timestamp v2 expiry set to day 21
      - Second updater refresh performed on day 18,
        it is successful and timestamp/snaphot final versions are v2"""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
 
@@ -144,12 +143,12 @@ def test_expired_metadata(
 
 
 def test_timestamp_expired(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """Tests a case where the timestamp metadata is expired.
     Checks whether the clients updates the timestamp metadata
     if the repo has a newer version, but it is expired"""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -166,10 +165,10 @@ def test_timestamp_expired(
 
 
 def test_TestDelegateConsistentSnapshotDisabled(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # https://github.com/theupdateframework/go-tuf/blob/f1d8916f08e4dd25f91e40139137edb8bf0498f3/metadata/updater/updater_consistent_snapshot_test.go#L97C6-L97C60
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -1,29 +1,25 @@
 import datetime
 import os
-
 from datetime import timezone
-from tuf_conformance.client_runner import ClientRunner
-from tuf_conformance.repository_simulator import RepositorySimulator
-from tuf_conformance.simulator_server import SimulatorServer
-from tuf_conformance import utils
-
+from pytest import FixtureRequest
 from tuf.api.metadata import (
     Timestamp, Snapshot, Root, Targets, Metadata,
     DelegatedRole
 )
 
+from tuf_conformance.client_runner import ClientRunner
+from tuf_conformance.simulator_server import SimulatorServer
+from tuf_conformance import utils
 
-def test_root_expired(client: ClientRunner,
-                      server: SimulatorServer) -> None:
+
+def test_root_expired(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """Tests a case where root is expired. The spec (5.3.10)
     says that the root should update, so at the end, this
     test asserts that root updates but no other metadata does"""
-    name = "test_root_expired"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
 
@@ -43,17 +39,14 @@ def test_root_expired(client: ClientRunner,
     assert client._version(Snapshot.type) == 1
 
 
-def test_snapshot_expired(client: ClientRunner,
-                          server: SimulatorServer) -> None:
+def test_snapshot_expired(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """Tests a case where the snapshot metadata is expired.
     Checks whether the clients updates the snapshot metadata
     if the repo has a newer version, but it is expired"""
-    name = "test_snapshot_expired"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     # Sanity check
@@ -73,17 +66,14 @@ def test_snapshot_expired(client: ClientRunner,
     assert client._version(Snapshot.type) == 1
 
 
-def test_targets_expired(client: ClientRunner,
-                         server: SimulatorServer) -> None:
+def test_targets_expired(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """Tests a case where the targets metadata is expired.
     Checks whether the clients updates the targets metadata
     if the repo has a newer version, but it is expired"""
-    name = "test_targets_expired"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     assert client._files_exist([Root.type,
@@ -106,8 +96,9 @@ def test_targets_expired(client: ClientRunner,
     assert client._version(Targets.type) == 1
 
 
-def test_expired_metadata(client: ClientRunner,
-                          server: SimulatorServer) -> None:
+def test_expired_metadata(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """Verifies that expired local timestamp/snapshot can be used for
     updating from remote.
 
@@ -118,12 +109,8 @@ def test_expired_metadata(client: ClientRunner,
      - Timestamp v2 expiry set to day 21
      - Second updater refresh performed on day 18,
        it is successful and timestamp/snaphot final versions are v2"""
-    name = "test_expired_metadata"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
 
     now = datetime.datetime.now(timezone.utc)
@@ -156,18 +143,14 @@ def test_expired_metadata(client: ClientRunner,
     assert client._version(Snapshot.type) == 2
 
 
-def test_timestamp_expired(client: ClientRunner,
-                           server: SimulatorServer) -> None:
+def test_timestamp_expired(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """Tests a case where the timestamp metadata is expired.
     Checks whether the clients updates the timestamp metadata
     if the repo has a newer version, but it is expired"""
+    init_data, repo = server.new_test(request.node.originalname)
 
-    name = "test_timestamp_expired"
-
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     assert client._version(Timestamp.type) == 1
@@ -183,15 +166,11 @@ def test_timestamp_expired(client: ClientRunner,
 
 
 def test_TestDelegateConsistentSnapshotDisabled(
-    client: ClientRunner, server: SimulatorServer
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
 ) -> None:
     # https://github.com/theupdateframework/go-tuf/blob/f1d8916f08e4dd25f91e40139137edb8bf0498f3/metadata/updater/updater_consistent_snapshot_test.go#L97C6-L97C60
-    name = "test_TestDelegatesRolesUpdateWithConsistentSnapshotDisabled"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     # Sanity check

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -1,5 +1,4 @@
 import os
-from pytest import FixtureRequest
 from tuf.api.metadata import Snapshot
 
 from tuf_conformance.repository_simulator import RepositorySimulator
@@ -20,12 +19,12 @@ def get_url_prefix(server_process_handler: utils.TestServerProcess,
 
 # TODO: Needs work
 def test_downloaded_file_is_correct(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """ A test that upgrades the version of one of the
     files in snapshot.json only but does does not upgrade
     in the file itself."""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)
@@ -80,11 +79,11 @@ def test_downloaded_file_is_correct(
 
 # TODO: Needs work
 def test_downloaded_file_is_correct2(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # A test that upgrades the version of one of the files in
     # snapshot.json only but does does not upgrade in the file itself.
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)
@@ -165,11 +164,11 @@ def test_downloaded_file_is_correct2(
 
 # TODO: Needs work
 def test_downloaded_file_is_correct3(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """A test that upgrades the version of one of the files in 
     snapshot.json only but does does not upgrade in the file itself."""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)
@@ -247,9 +246,9 @@ def test_downloaded_file_is_correct3(
             assert last_download_file.read() == file_contents.decode()
 
 def test_multiple_changes_to_target(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -1,14 +1,12 @@
 import os
+from pytest import FixtureRequest
+from tuf.api.metadata import Snapshot
 
 from tuf_conformance.repository_simulator import RepositorySimulator
 from tuf_conformance.simulator_server import SimulatorServer
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance import utils
 from tuf_conformance.utils import TestTarget
-
-from tuf.api.metadata import (
-    Snapshot
-)
 
 
 def get_url_prefix(server_process_handler: utils.TestServerProcess,
@@ -22,17 +20,12 @@ def get_url_prefix(server_process_handler: utils.TestServerProcess,
 
 # TODO: Needs work
 def test_downloaded_file_is_correct(
-    client: ClientRunner, server: SimulatorServer
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
 ) -> None:
     """ A test that upgrades the version of one of the
     files in snapshot.json only but does does not upgrade
     in the file itself."""
-    name = "test_downloaded_file_is_correct"
-
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
+    init_data, repo = server.new_test(request.node.originalname)
 
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)
@@ -86,16 +79,13 @@ def test_downloaded_file_is_correct(
         assert donwloaded_file_contents == file_contents_str
 
 # TODO: Needs work
-def test_downloaded_file_is_correct2(client: ClientRunner,
-                                     server: SimulatorServer) -> None:
+def test_downloaded_file_is_correct2(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     # A test that upgrades the version of one of the files in
     # snapshot.json only but does does not upgrade in the file itself.
-    name = "test_downloaded_file_is_correct2"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)
 
@@ -174,16 +164,13 @@ def test_downloaded_file_is_correct2(client: ClientRunner,
         assert last_download_file.read() == file_contents_str
 
 # TODO: Needs work
-def test_downloaded_file_is_correct3(client: ClientRunner,
-                                     server: SimulatorServer) -> None:
+def test_downloaded_file_is_correct3(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """A test that upgrades the version of one of the files in 
     snapshot.json only but does does not upgrade in the file itself."""
-    name = "test_downloaded_file_is_correct3"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)
 
@@ -259,14 +246,11 @@ def test_downloaded_file_is_correct3(client: ClientRunner,
         with open(client.get_last_downloaded_target(), "r") as last_download_file:
             assert last_download_file.read() == file_contents.decode()
 
-def test_multiple_changes_to_target(client: ClientRunner,
-                                    server: SimulatorServer) -> None:
-    name = "test_multiple_changes_to_target"
+def test_multiple_changes_to_target(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     server_process_handler = utils.TestServerProcess(log=utils.logger)
 

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -1,11 +1,12 @@
-from tuf_conformance.repository_simulator import RepositorySimulator
-from tuf_conformance.simulator_server import SimulatorServer, ClientInitData
-from tuf_conformance.client_runner import ClientRunner
+from pytest import FixtureRequest
 from securesystemslib.signer import CryptoSigner
-
 from tuf.api.metadata import (
     Timestamp, Snapshot, Root, Targets
 )
+
+from tuf_conformance.repository_simulator import RepositorySimulator
+from tuf_conformance.simulator_server import SimulatorServer, ClientInitData
+from tuf_conformance.client_runner import ClientRunner
 
 
 def initial_setup_for_key_threshold(client: ClientRunner,
@@ -37,18 +38,15 @@ def initial_setup_for_key_threshold(client: ClientRunner,
     assert client._version(Root.type) == 4
 
 
-def test_root_has_keys_but_not_snapshot(client: ClientRunner,
-                                        server: SimulatorServer) -> None:
+def test_root_has_keys_but_not_snapshot(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """This test adds keys to the repo root MD to test for cases
     where are client might calculate the threshold from only the
     roots keys and not check that the snapshot MD has the same
     keys"""
-    name = "test_root_has_keys_but_not_snapshot"
+    init_data, repo = server.new_test(request.node.originalname)
 
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     # Sanity checks
@@ -85,17 +83,13 @@ def test_root_has_keys_but_not_snapshot(client: ClientRunner,
     assert client._version(Snapshot.type) == 3
 
 
-def test_wrong_hashing_algorithm(client: ClientRunner,
-                                 server: SimulatorServer) -> None:
+def test_wrong_hashing_algorithm(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
     """This test sets a wrong but valid hashing algorithm for a key
     in the root MD. The client should not care and still update"""
+    init_data, repo = server.new_test(request.node.originalname)
 
-    name = "test_wrong_hashing_algorithm"
-
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
 
@@ -127,15 +121,11 @@ def test_wrong_hashing_algorithm(client: ClientRunner,
 
 
 def test_snapshot_threshold(
-    client: ClientRunner, server: SimulatorServer
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
 ) -> None:
-    # Tests that add_key works as intended
+    # Test basic failure to reach signature threshold
+    init_data, repo = server.new_test(request.node.originalname)
 
-    name = "test_snapshot_threshold"
-
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
 
@@ -161,19 +151,14 @@ def test_snapshot_threshold(
     assert client._version(Snapshot.type) == 1
 
 
-# Set/keep a threshold of 10 keys. All the keyids are different,
-# but the keys are all identical. As such, the snapshot metadata
-# has been signed by 1 key.
-def test_duplicate_keys_root(client: ClientRunner,
-                             server: SimulatorServer) -> None:
-    # Tests that add_key works as intended
+def test_duplicate_keys_root(
+    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+) -> None:
+    # Set/keep a threshold of 10 keys. All the keyids are different,
+    # but the keys are all identical. As such, the snapshot metadata
+    # has been signed by 1 key.
+    init_data, repo = server.new_test(request.node.originalname)
 
-    name = "test_duplicate_keys_root"
-
-    # initialize a simulator with repository content we need
-    repo = RepositorySimulator()
-    server.repos[name] = repo
-    init_data = server.get_client_init_data(name)
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
     # Sanity checks
@@ -183,7 +168,6 @@ def test_duplicate_keys_root(client: ClientRunner,
                                 Targets.type])
     assert client._version(Snapshot.type) == 1
 
-    # Add the same key 9 times
     signer = CryptoSigner.generate_ecdsa()
 
     # Add one key 9 times to root

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -1,4 +1,3 @@
-from pytest import FixtureRequest
 from securesystemslib.signer import CryptoSigner
 from tuf.api.metadata import (
     Timestamp, Snapshot, Root, Targets
@@ -39,13 +38,13 @@ def initial_setup_for_key_threshold(client: ClientRunner,
 
 
 def test_root_has_keys_but_not_snapshot(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """This test adds keys to the repo root MD to test for cases
     where are client might calculate the threshold from only the
     roots keys and not check that the snapshot MD has the same
     keys"""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -84,11 +83,11 @@ def test_root_has_keys_but_not_snapshot(
 
 
 def test_wrong_hashing_algorithm(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """This test sets a wrong but valid hashing algorithm for a key
     in the root MD. The client should not care and still update"""
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -121,10 +120,10 @@ def test_wrong_hashing_algorithm(
 
 
 def test_snapshot_threshold(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Test basic failure to reach signature threshold
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
@@ -152,12 +151,12 @@ def test_snapshot_threshold(
 
 
 def test_duplicate_keys_root(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Set/keep a threshold of 10 keys. All the keyids are different,
     # but the keys are all identical. As such, the snapshot metadata
     # has been signed by 1 key.
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -1,4 +1,3 @@
-from pytest import FixtureRequest
 from tuf.api.metadata import (
     Timestamp, Snapshot, Root, Targets
 )
@@ -9,9 +8,9 @@ from tuf_conformance.simulator_server import SimulatorServer
 
 
 def test_new_snapshot_version_rollback(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
 
@@ -28,9 +27,9 @@ def test_new_snapshot_version_rollback(
 
 
 def test_new_timestamp_version_rollback(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
 
@@ -51,9 +50,9 @@ def test_new_timestamp_version_rollback(
 
 
 def test_new_timestamp_snapshot_rollback(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
 
@@ -79,7 +78,7 @@ def test_new_timestamp_snapshot_rollback(
 
 
 def test_new_targets_fast_forward_recovery(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """Test targets fast-forward recovery using key rotation.
 
@@ -91,7 +90,7 @@ def test_new_targets_fast_forward_recovery(
         - Rollback the target version
     """
 
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
     assert client.init_client(init_data) == 0
 
     repo.md_targets.signed.version = 99999
@@ -111,7 +110,7 @@ def test_new_targets_fast_forward_recovery(
 
 
 def test_new_snapshot_fast_forward_recovery(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """Test snapshot fast-forward recovery using key rotation.
 
@@ -123,7 +122,7 @@ def test_new_snapshot_fast_forward_recovery(
     - Bump and publish root
     - Bump the timestamp
     """
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     repo.snapshot.version = 99999
@@ -146,11 +145,11 @@ def test_new_snapshot_fast_forward_recovery(
 
 
 def test_new_snapshot_version_mismatch(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Check against timestamp role's snapshot version
 
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
 
@@ -163,7 +162,7 @@ def test_new_snapshot_version_mismatch(
 
 
 def test_new_timestamp_fast_forward_recovery(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     """The timestamp recovery is made by the following steps
      - Remove the timestamp key
@@ -172,7 +171,7 @@ def test_new_timestamp_fast_forward_recovery(
      - Rollback the timestamp version
     """
 
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
 
@@ -195,12 +194,12 @@ def test_new_timestamp_fast_forward_recovery(
 
 
 def test_snapshot_rollback_with_local_snapshot_hash_mismatch(
-    client: ClientRunner, request: FixtureRequest, server: SimulatorServer
+    client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Test triggering snapshot rollback check on a newly downloaded snapshot
     # when the local snapshot is loaded even when there is a hash mismatch
     # with timestamp.snapshot_meta.
-    init_data, repo = server.new_test(request.node.originalname)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)


### PR DESCRIPTION
* get rid of string names for tests: use request.node.originalname
* Do the repository and client data setup in one call to remove 3 lines of boiler plate from each test
* standardize whitespace use in function argument list (this should be compatible with code formatters)

Note: I'm pretty sure we could avoid the RequestFixture argument to every test by being clever in the server fixture... but the pytest fixtures are so magical to me that I decided to keep the usage to the simplest possible even if that meant more changed lines in this PR  