### PR TITLE
Add repo dump feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ we can now run the test:
     --repository-dump-dir /tmp/test-repos   # dump repository contents
 
 # take a look at the repository targets.json that got debug dumped
-cat /tmp/test-repos/test_targets_version/1/targets.json
-cat /tmp/test-repos/test_targets_version/1/snapshot.json
+cat /tmp/test-repos/test_targets_version/refresh-1/targets.json
+cat /tmp/test-repos/test_targets_version/refresh-1/snapshot.json
 ```
 
 The metadata looks as expected (targets version is 7) so we can add a modification to the end of the test:
@@ -110,8 +110,8 @@ Running the test again results in a second repository version being dumped (each
     --repository-dump-dir /tmp/test-repos   # dump repository contents
 
 # take a look at targets versions in both snapshot versions that got debug dumped
-cat /tmp/test-repos/test_targets_version/1/snapshot.json
-cat /tmp/test-repos/test_targets_version/2/snapshot.json
+cat /tmp/test-repos/test_targets_version/refresh-1/snapshot.json
+cat /tmp/test-repos/test_targets_version/refresh-2/snapshot.json
 ```
 
 The repository metadata looks as expected (but not spec-compliant) so we can add some asserts for client behaviour now.

--- a/action.yml
+++ b/action.yml
@@ -28,13 +28,25 @@ runs:
       shell: bash
 
     - name: Run test suite
-      id: sigstore-conformance
+      id: tuf-conformance
       env:
         ENTRYPOINT: ${{ inputs.entrypoint }}
         EXPECTED_FAILURES: ${{ inputs.expected-failures }}
         TEST_LOCATION: ${{ github.action_path }}/tuf_conformance
       run: |
+        # create a sanitized name for the artifact upload
+        echo "NAME=${ENTRYPOINT##*/}" >> "$GITHUB_OUTPUT"
+
+        # run test suite
         pytest -v "$TEST_LOCATION" \
           --entrypoint "$ENTRYPOINT" \
-          --expected-failures "$EXPECTED_FAILURES"
+          --expected-failures "$EXPECTED_FAILURES" \
+          --repository-dump-dir ./test-repositories \
       shell: bash
+
+    - name: Upload repository dump
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      with:
+        name: test repositories for '${{ steps.tuf-conformance.outputs.NAME }}'
+        path: test-repositories

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -51,6 +51,9 @@ class ClientRunner:
         return self._run(cmd)
 
     def refresh(self, data: ClientInitData, days_in_future=0) -> int:
+        # dump a repository version for each client refresh (if configured to)
+        self._server.debug_dump(self.test_name)
+
         cmd = self._cmd
         if days_in_future:
             cmd = ["faketime", "-f", f"+{days_in_future}d"] + cmd

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -74,7 +74,7 @@ class ClientRunner:
                                       "download"]
         return self._run(cmd)
 
-    def _version(self, role: str) -> None:
+    def version(self, role: str) -> None:
         """Returns the version of a metadata role"""
         md = MetadataTest.from_file(os.path.join(self.metadata_dir, f"{role}.json"))
         return md.signed.version

--- a/tuf_conformance/conftest.py
+++ b/tuf_conformance/conftest.py
@@ -20,16 +20,25 @@ def pytest_addoption(parser) -> None:
         required=False,
         type=str,
     )
+    parser.addoption(
+        "--repository-dump-dir",
+        action="store",
+        help="Optional path to dump repository versions for each test for debugging",
+        required=False,
+        type=str,
+    )
 
 
 @pytest.fixture
-def server():
+def server(pytestconfig):
     """
     Parametrize each test with the server under test.
     """
-    server = SimulatorServer()
+    dump_dir = pytestconfig.getoption("--repository-dump-dir")
+    server = SimulatorServer(dump_dir)
     yield server
     server.server_close()
+
 
 @pytest.fixture
 def client(pytestconfig, server, request):

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -467,7 +467,7 @@ class RepositorySimulator():
             return
 
         self.dump_version += 1
-        dest_dir = os.path.join(self.dump_dir, str(self.dump_version))
+        dest_dir = os.path.join(self.dump_dir, f"refresh-{self.dump_version}")
         os.makedirs(dest_dir, exist_ok=True)
 
         for ver in range(1, len(self.signed_roots) + 1):

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -75,7 +75,7 @@ class RepositorySimulator():
     """Simulates a TUF repository that can be used for testing."""
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self) -> None:
+    def __init__(self, dump_dir: str | None) -> None:
         self.md_delegates: Dict[str, Metadata[Targets]] = {}
 
         # other metadata is signed on-demand (when fetched) but roots must be
@@ -95,7 +95,7 @@ class RepositorySimulator():
         # Enable hash-prefixed target file names
         self.prefix_targets_with_hash = True
 
-        self.dump_dir: Optional[str] = None
+        self.dump_dir = dump_dir
         self.dump_version = 0
 
         self.metadata_statistics: List[Tuple[str, Optional[int]]] = []
@@ -197,6 +197,7 @@ class RepositorySimulator():
                 role = ver_and_name
                 version = None
 
+            self.metadata_statistics.append((role, version))
             return self.fetch_metadata(role, version)
         elif path.startswith("targets/"):
             # figure out target path and hash prefix
@@ -209,6 +210,7 @@ class RepositorySimulator():
                 prefix, _, filename = prefixed_filename.partition(".")
             target_path = f"{dir_parts}{sep}{filename}"
 
+            self.artifact_statistics.append((target_path, target_hash))
             return self.fetch_target(target_path, prefix)
         raise ValueError(f"Unknown path '{path}'")
 
@@ -219,7 +221,6 @@ class RepositorySimulator():
 
         If hash is None, then consistent_snapshot is not used.
         """
-        self.artifact_statistics.append((target_path, target_hash))
 
         repo_target = self.artifacts.get(target_path)
         if repo_target is None:
@@ -240,7 +241,6 @@ class RepositorySimulator():
 
         If version is None, non-versioned metadata is being requested.
         """
-        self.metadata_statistics.append((role, version))
         # decode role for the metadata
         role = parse.unquote(role, encoding="utf-8")
 
@@ -455,19 +455,20 @@ class RepositorySimulator():
 
         delegator.add_key(signer.public_key)
 
-    def write(self) -> None:
+    def debug_dump(self) -> None:
         """Dump current repository metadata to self.dump_dir
 
         This is a debugging tool: dumping repository state before running
         Updater refresh may be useful while debugging a test.
+
+        If dump_dir is None, dumping does not happen
         """
-        if self.dump_dir is None:
-            self.dump_dir = tempfile.mkdtemp()
-            print(f"Repository Simulator dumps in {self.dump_dir}")
+        if not self.dump_dir:
+            return
 
         self.dump_version += 1
         dest_dir = os.path.join(self.dump_dir, str(self.dump_version))
-        os.makedirs(dest_dir)
+        os.makedirs(dest_dir, exist_ok=True)
 
         for ver in range(1, len(self.signed_roots) + 1):
             with open(os.path.join(dest_dir, f"{ver}.root.json"), "wb") as f:

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -31,7 +31,7 @@ def test_TestTimestampEqVersionsCheck(
 
     client.refresh(init_data)
 
-    assert client._version(Timestamp.type) == initial_timestamp_meta_ver
+    assert client.version(Timestamp.type) == initial_timestamp_meta_ver
 
 
 def test_new_targets_hash_mismatch(
@@ -61,8 +61,8 @@ def test_new_targets_hash_mismatch(
     repo.update_timestamp()
 
     client.refresh(init_data)
-    assert client._version(Snapshot.type) == 1
-    assert client._version(Targets.type) == 1
+    assert client.version(Snapshot.type) == 1
+    assert client.version(Targets.type) == 1
 
 
 def test_new_targets_version_mismatch(
@@ -159,4 +159,4 @@ def test_custom_fields(
 
     # client should accept new root: The signed content contains the unknown fields
     assert client.refresh(init_data) == 0
-    assert client._version(Root.type) == 2
+    assert client.version(Root.type) == 2

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -93,14 +93,9 @@ def test_basic_init_and_refresh(
     init_data, repo = server.new_test(client.test_name)
 
     # Run the test: step 1:  initialize client
-    # TODO verify success?
     assert client.init_client(init_data) == 0
 
-    # TODO verify that results are correct, see e.g.
-    # * repo.metadata_statistics: no requests expected
-    # * client metadat cache should contain root v1
-
-    # Run the test: step 1: Refresh
+    # Run the test: step 2: Refresh
     assert client.refresh(init_data) == 0
 
     # Verify that expected requests were made
@@ -108,8 +103,12 @@ def test_basic_init_and_refresh(
                                         ('timestamp', None),
                                         ('snapshot', 1),
                                         ('targets', 1)]
-    # TODO verify that local metadata cache has the files we expect
 
+    #verify client metadata looks as expected
+    assert client.version(Root.type) == 1
+    assert client.version(Timestamp.type) == 1
+    assert client.version(Snapshot.type) == 1
+    assert client.version(Targets.type) == 1
 
 def test_timestamp_eq_versions_check(
     client: ClientRunner, server: SimulatorServer

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -104,8 +104,7 @@ def test_basic_init_and_refresh(
     assert client.refresh(init_data) == 0
 
     # Verify that expected requests were made
-    assert repo.metadata_statistics == [('root', 1),
-                                        ('root', 2),
+    assert repo.metadata_statistics == [('root', 2),
                                         ('timestamp', None),
                                         ('snapshot', 1),
                                         ('targets', 1)]

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -33,9 +33,9 @@ def test_root_expired(
 
     # Clients should check for a freeze attack after persisting (5.3.10),
     # so root should update, but no other MD should update
-    assert client._version(Root.type) == 3
-    assert client._version(Timestamp.type) == 1
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Root.type) == 3
+    assert client.version(Timestamp.type) == 1
+    assert client.version(Snapshot.type) == 1
 
 
 def test_snapshot_expired(
@@ -62,7 +62,7 @@ def test_snapshot_expired(
     # Check that the client still has the correct metadata files
     # i.e. that it has not updated to the expired metadata
     assert client._files_exist([Root.type, Timestamp.type])
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Snapshot.type) == 1
 
 
 def test_targets_expired(
@@ -92,7 +92,7 @@ def test_targets_expired(
                                 Targets.type])
 
     # Client should not bump targets version, because it has expired
-    assert client._version(Targets.type) == 1
+    assert client.version(Targets.type) == 1
 
 
 def test_expired_metadata(
@@ -137,9 +137,9 @@ def test_expired_metadata(
     # which means a successful refresh is performed
     # with expired local metadata.
 
-    assert client._version(Targets.type) == 2
-    assert client._version(Timestamp.type) == 3
-    assert client._version(Snapshot.type) == 2
+    assert client.version(Targets.type) == 2
+    assert client.version(Timestamp.type) == 3
+    assert client.version(Snapshot.type) == 2
 
 
 def test_timestamp_expired(
@@ -152,7 +152,7 @@ def test_timestamp_expired(
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
-    assert client._version(Timestamp.type) == 1
+    assert client.version(Timestamp.type) == 1
 
     repo.timestamp.expires = utils.get_date_n_days_in_past(5)
     repo.update_timestamp()  # v2
@@ -161,7 +161,7 @@ def test_timestamp_expired(
 
     # Check that client resisted rollback attack
     assert client._files_exist([Root.type])
-    assert client._version(Timestamp.type) == 1
+    assert client.version(Timestamp.type) == 1
 
 
 def test_TestDelegateConsistentSnapshotDisabled(

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -33,8 +33,8 @@ def initial_setup_for_key_threshold(client: ClientRunner,
     assert len(repo.root.roles[Snapshot.type].keyids) == 4
 
     assert client.refresh(init_data) == 0
-    assert client._version(Snapshot.type) == 3
-    assert client._version(Root.type) == 4
+    assert client.version(Snapshot.type) == 3
+    assert client.version(Root.type) == 4
 
 
 def test_root_has_keys_but_not_snapshot(
@@ -53,7 +53,7 @@ def test_root_has_keys_but_not_snapshot(
                                 Timestamp.type,
                                 Snapshot.type,
                                 Targets.type])
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Snapshot.type) == 1
     assert len(repo.md_snapshot.signatures) == 1
 
     initial_setup_for_key_threshold(client, repo, init_data)
@@ -64,8 +64,8 @@ def test_root_has_keys_but_not_snapshot(
 
     # Updating should fail. Root should bump, but not snapshot
     assert client.refresh(init_data) == 1
-    assert client._version(Root.type) == 5
-    assert client._version(Snapshot.type) == 3
+    assert client.version(Root.type) == 5
+    assert client.version(Snapshot.type) == 3
 
     # Add two invalid keys only to root and expect the client
     # to fail updating
@@ -78,8 +78,8 @@ def test_root_has_keys_but_not_snapshot(
 
     # Updating should fail. Root should bump, but not snapshot
     assert client.refresh(init_data) == 1
-    assert client._version(Root.type) == 5
-    assert client._version(Snapshot.type) == 3
+    assert client.version(Root.type) == 5
+    assert client.version(Snapshot.type) == 3
 
 
 def test_wrong_hashing_algorithm(
@@ -115,8 +115,8 @@ def test_wrong_hashing_algorithm(
     # main assertion: That the client updates so that it has the
     # same metadata as the repository.
     assert client.refresh(init_data) == 0
-    assert client._version(Root.type) == repo._version(Root.type)
-    assert client._version(Snapshot.type) == repo._version(Snapshot.type)
+    assert client.version(Root.type) == repo._version(Root.type)
+    assert client.version(Snapshot.type) == repo._version(Snapshot.type)
 
 
 def test_snapshot_threshold(
@@ -147,7 +147,7 @@ def test_snapshot_threshold(
     # Ensure that client does not update because it does
     # not have enough keys.
     assert client.refresh(init_data) == 1
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Snapshot.type) == 1
 
 
 def test_duplicate_keys_root(
@@ -165,7 +165,7 @@ def test_duplicate_keys_root(
                                 Timestamp.type,
                                 Snapshot.type,
                                 Targets.type])
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Snapshot.type) == 1
 
     signer = CryptoSigner.generate_ecdsa()
 
@@ -188,7 +188,7 @@ def test_duplicate_keys_root(
 
     # Sanity check that the clients snapshot
     # metadata is version 1
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Snapshot.type) == 1
 
     # This should fail because the metadata should not have
     # the same key in more than 1 keyids. We check failure
@@ -198,4 +198,4 @@ def test_duplicate_keys_root(
 
     # The clients snapshot metadata should still
     # be version 1
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Snapshot.type) == 1

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -23,7 +23,7 @@ def test_new_snapshot_version_rollback(
     client.refresh(init_data)
 
     # Check that client resisted rollback attack
-    assert client._version(Snapshot.type) == 2
+    assert client.version(Snapshot.type) == 2
 
 
 def test_new_timestamp_version_rollback(
@@ -38,7 +38,7 @@ def test_new_timestamp_version_rollback(
     assert client.refresh(init_data) == 0
 
     # Sanity check that client saw the snapshot update:
-    assert client._version(Timestamp.type) == 2
+    assert client.version(Timestamp.type) == 2
 
     # Repository attempts rollback attack:
     repo.downgrade_timestamp()  # v1
@@ -46,7 +46,7 @@ def test_new_timestamp_version_rollback(
     assert client.refresh(init_data) == 1
 
     # Check that client resisted rollback attack
-    assert client._version(Timestamp.type) == 2
+    assert client.version(Timestamp.type) == 2
 
 
 def test_new_timestamp_snapshot_rollback(
@@ -68,13 +68,13 @@ def test_new_timestamp_snapshot_rollback(
     repo.md_snapshot.signed.version = 1
     repo.update_timestamp()  # v4
     assert repo._version(Timestamp.type) == 4
-    assert client._version(Timestamp.type) == 3
+    assert client.version(Timestamp.type) == 3
 
     client.refresh(init_data)
 
     # Check that client resisted rollback attack
-    assert client._version(Timestamp.type) == 3
-    assert client._version(Snapshot.type) == 2
+    assert client.version(Timestamp.type) == 3
+    assert client.version(Snapshot.type) == 2
 
 
 def test_new_targets_fast_forward_recovery(
@@ -97,7 +97,7 @@ def test_new_targets_fast_forward_recovery(
     repo.update_snapshot()  # v2
 
     assert client.refresh(init_data) == 0
-    assert client._version(Targets.type) == 99999
+    assert client.version(Targets.type) == 99999
 
     repo.rotate_keys(Snapshot.type)
     repo.bump_root_by_one()
@@ -106,7 +106,7 @@ def test_new_targets_fast_forward_recovery(
     repo.update_snapshot()  # v3
 
     client.refresh(init_data)
-    assert client._version(Targets.type) == 1
+    assert client.version(Targets.type) == 1
 
 
 def test_new_snapshot_fast_forward_recovery(
@@ -130,7 +130,7 @@ def test_new_snapshot_fast_forward_recovery(
 
     # client refreshes the metadata and see the new snapshot version
     client.refresh(init_data)
-    assert client._version(Snapshot.type) == 99999
+    assert client.version(Snapshot.type) == 99999
 
     repo.rotate_keys(Snapshot.type)
     repo.rotate_keys(Timestamp.type)
@@ -141,7 +141,7 @@ def test_new_snapshot_fast_forward_recovery(
     repo.update_timestamp()
 
     client.refresh(init_data)
-    assert client._version(Snapshot.type) == 1
+    assert client.version(Snapshot.type) == 1
 
 
 def test_new_snapshot_version_mismatch(
@@ -180,7 +180,7 @@ def test_new_timestamp_fast_forward_recovery(
 
     # client refreshes the metadata and see the new timestamp version
     client.refresh(init_data)
-    assert client._version(Timestamp.type) == 99999
+    assert client.version(Timestamp.type) == 99999
 
     # repository rotates timestamp keys,
     # rolls back timestamp version
@@ -190,7 +190,7 @@ def test_new_timestamp_fast_forward_recovery(
 
     # client refresh the metadata and see the initial timestamp version
     client.refresh(init_data)
-    assert client._version(Timestamp.type) == 1
+    assert client.version(Timestamp.type) == 1
 
 
 def test_snapshot_rollback_with_local_snapshot_hash_mismatch(
@@ -213,7 +213,7 @@ def test_snapshot_rollback_with_local_snapshot_hash_mismatch(
     repo.md_targets.signed.version = 2
     repo.update_snapshot()
     assert client.refresh(init_data) == 0
-    assert client._version(Targets.type) == 2
+    assert client.version(Targets.type) == 2
 
     # By raising this flag on timestamp update the simulator would:
     # 1) compute the hash of the new modified version of snapshot


### PR DESCRIPTION
* This adds a way to manually dump repository metadata
* the action enables dumping and uploads the repository dump as an artifact in the GitHub workflow run
* There is also and example added in the README and some cleanup commits