### PR TITLE
Use faketime in ClientRunner to get rid of "--days-in-future"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,13 @@
 # 
 # SPDX-License-Identifier: BSD-2-Clause
 
+FAKETIME := $(shell command -v faketime 2> /dev/null)
+all:
+ifndef FAKETIME
+    $(error "Program 'faketime' was not found. Please install it")
+endif
+
+
 #########################
 # tuf-conformance section
 #########################

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ There are two required steps:
 ## Development
 
 This repository contains two client-under-test CLI protocol implementations
-to enable easy development and testing. There is a Makefile that runs the test suite in
-virtual environment:
+to enable easy development and testing. The test suite depends on various
+python modules which will be installed by the make commands into a virtual environment.
+The suite also depends on `faketime` tool which needs to be available.
 
 ```bash
 # run against both clients or just one of them:

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ runs:
     - name: Install test
       run: |
         echo "::group::Install test suite and dependencies"
+        sudo apt install faketime
         pip install -e "${{ github.action_path }}"
         echo "::endgroup::"
       shell: bash

--- a/clients/README.md
+++ b/clients/README.md
@@ -9,7 +9,6 @@ Clients must implement the following command-line interface:
 `refresh`: Updates the local metadata from the repository.
 - `--metadata-dir`, Required: The localpath where the client stores metadata.
 - `--metadata-url`, Required: The URL to the repository. The test suite takes care of passing the URL to the local repository.
-- `--days-in-future`, Not required, defaults to `0`: A helper to fake time to a point in the future. Useful for testing expiration-related cases.
 - `--max-root-rotations`, Not required, defaults to `32`: The number of root rotations the client will allow from the repository. The client should not update if the repository has rotated keys more times than this.
 
 `download`: Downloads a target file.

--- a/clients/go-tuf/cmd/download.go
+++ b/clients/go-tuf/cmd/download.go
@@ -15,13 +15,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"time"
 
-	"github.com/theupdateframework/go-tuf/v2/metadata/config"
-	"github.com/theupdateframework/go-tuf/v2/metadata/updater"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/theupdateframework/go-tuf/v2/metadata/config"
+	"github.com/theupdateframework/go-tuf/v2/metadata/updater"
 )
 
 var downloadCmd = &cobra.Command{
@@ -48,7 +46,7 @@ var downloadCmd = &cobra.Command{
 
 		// refresh metadata and try to download the desired target
 		// first arg means the name of the target file to download
-		return RefreshAndDownloadCmd(targetInfoName, targetBaseUrl, targetDownloadDir, "0", 32, false)
+		return RefreshAndDownloadCmd(targetInfoName, targetBaseUrl, targetDownloadDir, 32, false)
 	},
 }
 
@@ -56,11 +54,10 @@ func init() {
 	rootCmd.AddCommand(downloadCmd)
 }
 
-func RefreshAndDownloadCmd(targetName,
-						   targetBaseUrl,
-						   targetDownloadDir,
-						   daysInFuture string, 
-						   maxRootRotations int, refreshOnly bool) error {
+func RefreshAndDownloadCmd(targetName string,
+	targetBaseUrl string,
+	targetDownloadDir string,
+	maxRootRotations int, refreshOnly bool) error {
 	// handle verbosity level
 	if FlagVerbosity {
 		log.SetLevel(log.DebugLevel)
@@ -87,12 +84,6 @@ func RefreshAndDownloadCmd(targetName,
 	up, err := updater.New(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create Updater instance: %w", err)
-	}
-
-	if daysInFuture != "0" {
-		laterDay, _ := strconv.Atoi(daysInFuture)
-		laterTime := time.Now().AddDate(0, 0, laterDay)
-		up.UnsafeSetRefTime(laterTime)
 	}
 
 	// try to build the top-level metadata

--- a/clients/go-tuf/cmd/refresh.go
+++ b/clients/go-tuf/cmd/refresh.go
@@ -27,16 +27,12 @@ var refreshCmd = &cobra.Command{
 			fmt.Println("Error: required flag(s): \"metadata-url\" or \"metadata-dir\" not set")
 			os.Exit(1)
 		}
-		daysInFuture, err := cmd.Flags().GetString("days-in-future")
-		if err != nil {
-			os.Exit(1)
-		}
 		maxRootRotations, err := cmd.Flags().GetInt("max-root-rotations")
 		if err != nil {
 			os.Exit(1)
 		}
 		// do a refresh only
-		return RefreshAndDownloadCmd("", "", "", daysInFuture, maxRootRotations, true)
+		return RefreshAndDownloadCmd("", "", "", maxRootRotations, true)
 	},
 }
 

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -20,7 +20,7 @@ class ClientRunner:
     ClientRunner manages client resources (like the cache paths etc)"""
     def __init__(self, client_cmd: str, server: SimulatorServer) -> None:
         self._server = server
-        self._cmd = client_cmd
+        self._cmd = client_cmd.split(" ")
         self._tempdir = TemporaryDirectory()
         self._target_dir = TemporaryDirectory()
         self._remote_target_dir = TemporaryDirectory(dir=os.getcwd())
@@ -47,19 +47,19 @@ class ClientRunner:
         with open(trusted, "bw") as f:
             f.write(data.trusted_root)
 
-        cmd = self._cmd.split(" ") + ["--metadata-dir", self.metadata_dir, "init", trusted]
+        cmd = self._cmd + ["--metadata-dir", self.metadata_dir, "init", trusted]
         return self._run(cmd)
 
-    def refresh(self, data: ClientInitData, days_in_future="0") -> int:
-        cmd = self._cmd.split(" ") + ["--metadata-url", data.metadata_url,
+    def refresh(self, data: ClientInitData, days_in_future=0) -> int:
+        cmd = self._cmd + ["--metadata-url", data.metadata_url,
                                       "--metadata-dir", self.metadata_dir,
-                                      "--days-in-future", days_in_future,
+                                      "--days-in-future", str(days_in_future),
                                       "--max-root-rotations", str(self.max_root_rotations),
                                       "refresh"]
         return self._run(cmd)
 
     def download_target(self, data: ClientInitData, target_name: str, target_base_url: str) -> int:
-        cmd = self._cmd.split(" ") + ["--metadata-url", data.metadata_url,
+        cmd = self._cmd + ["--metadata-url", data.metadata_url,
                                       "--metadata-dir", self.metadata_dir,
                                       "--target-name",target_name,
                                       "--target-dir", self._target_dir.name, 

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -51,11 +51,16 @@ class ClientRunner:
         return self._run(cmd)
 
     def refresh(self, data: ClientInitData, days_in_future=0) -> int:
-        cmd = self._cmd + ["--metadata-url", data.metadata_url,
-                                      "--metadata-dir", self.metadata_dir,
-                                      "--days-in-future", str(days_in_future),
-                                      "--max-root-rotations", str(self.max_root_rotations),
-                                      "refresh"]
+        cmd = self._cmd
+        if days_in_future:
+            cmd = ["faketime", "-f", f"+{days_in_future}d"] + cmd
+
+        cmd = cmd + [
+            "--metadata-url", data.metadata_url,
+            "--metadata-dir", self.metadata_dir,
+            "--max-root-rotations", str(self.max_root_rotations),
+            "refresh"
+        ]
         return self._run(cmd)
 
     def download_target(self, data: ClientInitData, target_name: str, target_base_url: str) -> int:

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -145,7 +145,7 @@ def test_expired_metadata(client: ClientRunner,
 
     # Mocking time so that local timestamp has expired
     # but the new timestamp has not
-    client.refresh(init_data, days_in_future="18")
+    client.refresh(init_data, days_in_future=18)
 
     # Assert that the final version of timestamp/snapshot is version 2
     # which means a successful refresh is performed


### PR DESCRIPTION
Fixes #93.

This makes the client CLI simpler by removing `--days-in-future`. 
* Instead the test suite now depends on faketime -- this is a little annoying as we did not have any non-Python dependencies before but I think acceptable
* Alternatively I could have used libfaketime directly without faketime binary (that way you can execute the client normally and just define some env variables like LD_PRELOAD... changing later on is easy if that is preferred) 
