### PR TITLE
Quote test name in repository URL

### DIFF
--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -67,7 +67,7 @@ class SimulatorServer(ThreadingHTTPServer):
         self.repos[name] = repo
 
         client_data = ClientInitData(
-            f"http://{self.server_address[0]}:{self.server_address[1]}/{name}/metadata/",
+            f"http://{self.server_address[0]}:{self.server_address[1]}/{parse.quote(name)}/metadata/",
             repo.fetch_metadata("root", 1)
         )
 


### PR DESCRIPTION
`[]` need to be quoted and occur when tests are parameterized