### PR TITLE
Add test for duplicate keyids

### DIFF
--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -7,7 +7,7 @@ from typing import Iterable, Optional
 from tuf_conformance.simulator_server import ClientInitData, SimulatorServer
 
 from tuf_conformance.metadata import (
-    MetadataTest
+    MetadataTest, JSONDeserializerTest
 )
 
 
@@ -76,7 +76,7 @@ class ClientRunner:
 
     def version(self, role: str) -> None:
         """Returns the version of a metadata role"""
-        md = MetadataTest.from_file(os.path.join(self.metadata_dir, f"{role}.json"))
+        md = MetadataTest.from_file(os.path.join(self.metadata_dir, f"{role}.json"), JSONDeserializerTest())
         return md.signed.version
 
     def _files_exist(self, roles: Iterable[str]) -> None:


### PR DESCRIPTION
Add test that is specified in https://github.com/theupdateframework/tuf-conformance/pull/86#issuecomment-2259995260 without the bonus test.

The two clients seem to disagree on whether root metadata should update if there are duplicate keys. As such, python-tuf does not fail on meeting the threshold, but rather because the root has duplicate keys.