### PR TITLE
SimulatorServer: fully quote test name in repository url

### DIFF
--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -72,8 +72,8 @@ class SimulatorServer(ThreadingHTTPServer):
         host, port = self.server_address[0], self.server_address[1]
         assert isinstance(host, str)
         client_data = ClientInitData(
-            f"http://{host}:{port}/{parse.quote(name)}/metadata/",
-            f"http://{host}:{port}/{parse.quote(name)}/targets/",
+            f"http://{host}:{port}/{parse.quote(name, '')}/metadata/",
+            f"http://{host}:{port}/{parse.quote(name, '')}/targets/",
             repo.fetch_metadata("root", 1),
         )
 


### PR DESCRIPTION
We're still not fully quoting the test name: In this case we want even "/" to be quoted so the test name can contain slashes without breaking the logic of parsing the url in do_GET()