### PR TITLE
Lint: enable more rulesets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,14 @@ lint = [
 [tool.hatch.version]
 path = "tuf_conformance/__init__.py"
 
+[tool.mypy]
+check_untyped_defs = "True"
+disallow_untyped_defs = "True"
+no_implicit_optional = "True"
+warn_return_any = "True"
+warn_unreachable = "True"
+warn_unused_ignores = "True"
+
 [[tool.mypy.overrides]]
 module = ["securesystemslib.*"]
 ignore_missing_imports = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["E", "F"]
+lint.select = ["E", "F", "W", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ path = "tuf_conformance/__init__.py"
 [[tool.mypy.overrides]]
 module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
+
+[tool.ruff]
+lint.select = ["E", "F"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pytest==8.3.2"
 ]
 dynamic = ["version"]
+requires-python = ">= 3.10"
 
 [project.optional-dependencies]
 lint = [
@@ -33,7 +34,7 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["ANN", "E", "F", "I", "N", "PL", "RUF", "S", "UP", "W",]
+lint.select = ["ANN", "E", "F", "I", "N", "PL", "PYI", "RUF", "S", "UP", "W",]
 lint.ignore = [
     "ANN101", "ANN102", # nonsense, deprecated in ruff
     "S101",             # assert is fine in pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["ANN", "E", "F", "I", "N", "PL", "S", "UP", "W",]
+lint.select = ["ANN", "E", "F", "I", "N", "PL", "RUF", "S", "UP", "W",]
 lint.ignore = [
     "ANN101", "ANN102", # nonsense, deprecated in ruff
     "S101",             # assert is fine in pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["ANN", "E", "F", "I", "N", "S", "UP", "W",]
+lint.select = ["ANN", "E", "F", "I", "N", "PL", "S", "UP", "W",]
 lint.ignore = [
     "ANN101", "ANN102", # nonsense, deprecated in ruff
-    "S101", # assert is fine in pytest tests
+    "S101",             # assert is fine in pytest tests
+    "PLR2004",          # magic values are ok in a test suite
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["ANN", "E", "F", "I", "N", "UP", "W",]
+lint.select = ["ANN", "E", "F", "I", "N", "S", "UP", "W",]
 lint.ignore = [
     "ANN101", "ANN102", # nonsense, deprecated in ruff
+    "S101", # assert is fine in pytest tests
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,7 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["E", "F", "I", "N", "UP", "W",]
+lint.select = ["ANN", "E", "F", "I", "N", "UP", "W",]
+lint.ignore = [
+    "ANN101", "ANN102", # nonsense, deprecated in ruff
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["E", "F", "W", "I"]
+lint.select = ["E", "F", "I", "N", "UP", "W",]

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -1,12 +1,11 @@
-import subprocess
-import os
 import glob
+import os
+import subprocess
 from tempfile import TemporaryDirectory
 from typing import Iterable
 
-from tuf_conformance.simulator_server import ClientInitData, SimulatorServer
-
 from tuf_conformance.metadata import MetadataTest
+from tuf_conformance.simulator_server import ClientInitData, SimulatorServer
 
 
 class ClientRunner:

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -55,7 +55,7 @@ class ClientRunner:
         cmd = self._cmd + ["--metadata-dir", self.metadata_dir, "init", trusted]
         return self._run(cmd)
 
-    def refresh(self, data: ClientInitData, days_in_future=0) -> int:
+    def refresh(self, data: ClientInitData, days_in_future: int = 0) -> int:
         # dump a repository version for each client refresh (if configured to)
         self._server.debug_dump(self.test_name)
 

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -1,8 +1,8 @@
 import glob
 import os
 import subprocess
+from collections.abc import Iterable
 from tempfile import TemporaryDirectory
-from typing import Iterable
 
 from tuf_conformance.metadata import MetadataTest
 from tuf_conformance.simulator_server import ClientInitData, SimulatorServer

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -42,7 +42,7 @@ class ClientRunner:
         return artifact_bytes
 
     def _run(self, cmd: list[str]) -> int:
-        popen = subprocess.Popen(cmd)
+        popen = subprocess.Popen(cmd)  # noqa: S603
         while popen.poll() is None:
             self._server.handle_request()
         return popen.returncode

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -52,7 +52,7 @@ class ClientRunner:
         with open(trusted, "bw") as f:
             f.write(data.trusted_root)
 
-        cmd = self._cmd + ["--metadata-dir", self.metadata_dir, "init", trusted]
+        cmd = [*self._cmd, "--metadata-dir", self.metadata_dir, "init", trusted]
         return self._run(cmd)
 
     def refresh(self, data: ClientInitData, days_in_future: int = 0) -> int:
@@ -61,9 +61,10 @@ class ClientRunner:
 
         cmd = self._cmd
         if days_in_future:
-            cmd = ["faketime", "-f", f"+{days_in_future}d"] + cmd
+            cmd = ["faketime", "-f", f"+{days_in_future}d", *cmd]
 
-        cmd = cmd + [
+        cmd = [
+            *cmd,
             "--metadata-url",
             data.metadata_url,
             "--metadata-dir",
@@ -73,7 +74,8 @@ class ClientRunner:
         return self._run(cmd)
 
     def download_target(self, data: ClientInitData, target_name: str) -> int:
-        cmd = self._cmd + [
+        cmd = [
+            *self._cmd,
             "--metadata-url",
             data.metadata_url,
             "--metadata-dir",

--- a/tuf_conformance/conftest.py
+++ b/tuf_conformance/conftest.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Iterator
 
 import pytest
 
@@ -6,7 +7,7 @@ from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer
 
 
-def pytest_addoption(parser) -> None:
+def pytest_addoption(parser: pytest.Parser) -> None:
     """Add `--entrypoint` flag to CLI."""
     parser.addoption(
         "--entrypoint",
@@ -32,7 +33,7 @@ def pytest_addoption(parser) -> None:
 
 
 @pytest.fixture
-def server(pytestconfig):
+def server(pytestconfig: pytest.Config) -> Iterator[SimulatorServer]:
     """
     Parametrize each test with the server under test.
     """
@@ -43,7 +44,9 @@ def server(pytestconfig):
 
 
 @pytest.fixture
-def client(pytestconfig, server, request):
+def client(
+    pytestconfig: pytest.Config, server: SimulatorServer, request: pytest.FixtureRequest
+) -> ClientRunner:
     """
     Parametrize each test with the client under test.
     """
@@ -55,7 +58,9 @@ def client(pytestconfig, server, request):
 
 
 @pytest.fixture(autouse=True)
-def conformance_xfail(pytestconfig, request):
+def conformance_xfail(
+    pytestconfig: pytest.Config, request: pytest.FixtureRequest
+) -> None:
     xfail_option = pytestconfig.getoption("--expected-failures")
     if xfail_option is None:
         return

--- a/tuf_conformance/conftest.py
+++ b/tuf_conformance/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from tuf_conformance.client_runner import ClientRunner

--- a/tuf_conformance/metadata.py
+++ b/tuf_conformance/metadata.py
@@ -95,7 +95,7 @@ class RoleTest(Role):
         keyids: List[str],
         threshold: int,
         unrecognized_fields: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> None:
         self.keyids = keyids
         self.threshold = threshold
         if unrecognized_fields is None:

--- a/tuf_conformance/metadata.py
+++ b/tuf_conformance/metadata.py
@@ -1,12 +1,7 @@
-from tuf.api.metadata import (
-    Metadata,
-    Key,
-)
-
 import json
+from typing import Any, Dict, List, Optional, Type, cast
 
 from securesystemslib.signer import Signature
-
 from tuf.api._payload import (
     _ROOT,
     _SNAPSHOT,
@@ -20,11 +15,13 @@ from tuf.api._payload import (
     Targets,
     Timestamp,
 )
+from tuf.api.metadata import (
+    Key,
+    Metadata,
+)
 from tuf.api.serialization.json import (
     MetadataDeserializer,
 )
-
-from typing import Dict, Any, cast, List, Optional, Type
 
 
 class MetadataTest(Metadata[T]):

--- a/tuf_conformance/metadata.py
+++ b/tuf_conformance/metadata.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Any, cast
 
 from securesystemslib.signer import Signature
 from tuf.api._payload import (
@@ -26,11 +26,11 @@ from tuf.api.serialization.json import (
 
 class MetadataTest(Metadata[T]):
     @classmethod
-    def from_dict(cls, metadata: Dict[str, Any]) -> "MetadataTest[T]":
+    def from_dict(cls, metadata: dict[str, Any]) -> "MetadataTest[T]":
         _type = metadata["signed"]["_type"]
 
         if _type == _TARGETS:
-            inner_cls: Type[Signed] = Targets
+            inner_cls: type[Signed] = Targets
         elif _type == _SNAPSHOT:
             inner_cls = Snapshot
         elif _type == _TIMESTAMP:
@@ -41,7 +41,7 @@ class MetadataTest(Metadata[T]):
             raise ValueError(f'unrecognized metadata type "{_type}"')
 
         # Make sure signatures are unique
-        signatures: Dict[str, Signature] = {}
+        signatures: dict[str, Signature] = {}
         for sig_dict in metadata.pop("signatures"):
             sig = Signature.from_dict(sig_dict)
             signatures[sig.keyid] = sig
@@ -67,7 +67,7 @@ class RootTest(Root):
         self.keys[key.keyid] = key
 
     @classmethod
-    def from_dict(cls, signed_dict: Dict[str, Any]) -> "Root":
+    def from_dict(cls, signed_dict: dict[str, Any]) -> "Root":
         """Create ``Root`` object from its json/dict representation.
 
         Raises:
@@ -92,9 +92,9 @@ class RoleTest(Role):
     # without validation
     def __init__(
         self,
-        keyids: List[str],
+        keyids: list[str],
         threshold: int,
-        unrecognized_fields: Optional[Dict[str, Any]] = None,
+        unrecognized_fields: dict[str, Any] | None = None,
     ) -> None:
         self.keyids = keyids
         self.threshold = threshold

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -39,8 +39,6 @@ from urllib import parse
 
 import securesystemslib.hash as sslib_hash
 from securesystemslib.signer import CryptoSigner, Signer
-from tuf_conformance.metadata import RootTest, MetadataTest
-
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     TOP_LEVEL_ROLE_NAMES,
@@ -56,6 +54,8 @@ from tuf.api.metadata import (
     Timestamp,
 )
 from tuf.api.serialization.json import JSONSerializer
+
+from tuf_conformance.metadata import MetadataTest, RootTest
 
 logger = logging.getLogger(__name__)
 

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from os import path
-from typing import Dict
 from urllib import parse
 
 from tuf_conformance.repository_simulator import RepositorySimulator
@@ -59,7 +58,7 @@ class SimulatorServer(ThreadingHTTPServer):
         self._dump_dir = dump_dir
 
         # key is test name, value is the repository sim for that test
-        self.repos: Dict[str, RepositorySimulator] = {}
+        self.repos: dict[str, RepositorySimulator] = {}
 
     def new_test(self, name: str) -> tuple[ClientInitData, RepositorySimulator]:
         """Return a tuple of

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -20,7 +20,7 @@ class _ReqHandler(BaseHTTPRequestHandler):
     Serves metadata and targets for multiple repositories
     """
 
-    def do_GET(self):  # noqa: N802
+    def do_GET(self) -> None:  # noqa: N802
         """Handle GET: metadata and target files"""
 
         test, _, path = self.path.lstrip("/").partition("/")
@@ -38,11 +38,11 @@ class _ReqHandler(BaseHTTPRequestHandler):
             self.send_error(404, str(e))
             return
         self.send_response(200)
-        self.send_header("Content-length", len(data))
+        self.send_header("Content-length", str(len(data)))
         self.end_headers()
         self.wfile.write(data)
 
-    def log_message(self, format, *args):
+    def log_message(self, format: str, *args: str) -> None:
         """Log an arbitrary message.
 
         Avoid output for now. TODO We may want to log in some situations?
@@ -53,7 +53,7 @@ class _ReqHandler(BaseHTTPRequestHandler):
 class SimulatorServer(ThreadingHTTPServer):
     """Web server to serve a number of repositories"""
 
-    def __init__(self, dump_dir: str | None):
+    def __init__(self, dump_dir: str | None) -> None:
         super().__init__(("127.0.0.1", 0), _ReqHandler)
         self.timeout = 0
         self._dump_dir = dump_dir
@@ -80,5 +80,5 @@ class SimulatorServer(ThreadingHTTPServer):
 
         return client_data, repo
 
-    def debug_dump(self, test_name):
+    def debug_dump(self, test_name: str) -> None:
         self.repos[test_name].debug_dump()

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -3,6 +3,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from os import path
 from typing import Dict
 from urllib import parse
+
 from tuf_conformance.repository_simulator import RepositorySimulator
 
 

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -20,7 +20,7 @@ class _ReqHandler(BaseHTTPRequestHandler):
     Serves metadata and targets for multiple repositories
     """
 
-    def do_GET(self):
+    def do_GET(self):  # noqa: N802
         """Handle GET: metadata and target files"""
 
         test, _, path = self.path.lstrip("/").partition("/")

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -1,10 +1,10 @@
 # Test runner
 import os
 
-from tuf_conformance.simulator_server import SimulatorServer
-from tuf_conformance.client_runner import ClientRunner
+from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
 
-from tuf.api.metadata import Timestamp, Snapshot, Root, Targets, Metadata
+from tuf_conformance.client_runner import ClientRunner
+from tuf_conformance.simulator_server import SimulatorServer
 
 
 def test_TestTimestampEqVersionsCheck(

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -7,9 +7,12 @@ from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer
 
 
-def test_TestTimestampEqVersionsCheck(
+def test_timestamp_content_changes(
     client: ClientRunner, server: SimulatorServer
 ) -> None:
+    """Repository modifies timestamp content without bumping a version. Expect client
+    to keep using the version it already has.
+    """
     # https://github.com/theupdateframework/go-tuf/blob/f1d8916f08e4dd25f91e40139137edb8bf0498f3/metadata/updater/updater_top_level_update_test.go#L1058
     init_data, repo = server.new_test(client.test_name)
 

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -1,11 +1,12 @@
 import datetime
 import os
 from datetime import timezone
-from tuf.api.metadata import Timestamp, Snapshot, Root, Targets, Metadata
 
+from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
+
+from tuf_conformance import utils
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer
-from tuf_conformance import utils
 
 
 def test_root_expired(client: ClientRunner, server: SimulatorServer) -> None:

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -87,7 +87,7 @@ def test_repository_substitutes_target_file(
     repo.artifacts[target_path_2].data = malicious_content
 
     # ask client to download again
-    # NOTE: this may either succeed (if client cached the artifact and never tries to re-download)
+    # NOTE: this may succeed (if client cached the artifact and never re-downloads)
     # or it might fail (if client downloads the new artifact and realizes it is invalid)
     client.download_target(init_data, target_path_1)
 
@@ -170,7 +170,7 @@ def test_multiple_changes_to_target(
         # check downloaded contents
         assert client.get_downloaded_target_bytes() == expected_downloads
 
-        # Modify the original artifact content without updating the hashes/length in metadata.
+        # Modify artifact content without updating the hashes/length in metadata.
         malicious_file_contents = f"malicious contents {i}".encode()
         repo.artifacts[target_path].data = malicious_file_contents
         repo.targets.version += 1
@@ -178,7 +178,8 @@ def test_multiple_changes_to_target(
         # Bump repo snapshot
         repo.update_snapshot()
 
-        # ask client to download (this may fail or succeed, see test_repository_substitutes_target_file)
+        # ask client to download (this may fail or succeed, see
+        # test_repository_substitutes_target_file)
         client.download_target(init_data, target_path)
 
         # Check that the client did not download the malicious file

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -1,7 +1,7 @@
 from tuf.api.metadata import Targets
 
-from tuf_conformance.simulator_server import SimulatorServer
 from tuf_conformance.client_runner import ClientRunner
+from tuf_conformance.simulator_server import SimulatorServer
 
 
 def test_client_downloads_expected_file(

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -1,9 +1,9 @@
 from securesystemslib.signer import CryptoSigner
-from tuf.api.metadata import Timestamp, Snapshot, Root, Targets
+from tuf.api.metadata import Root, Snapshot, Targets, Timestamp
 
-from tuf_conformance.repository_simulator import RepositorySimulator
-from tuf_conformance.simulator_server import SimulatorServer, ClientInitData
 from tuf_conformance.client_runner import ClientRunner
+from tuf_conformance.repository_simulator import RepositorySimulator
+from tuf_conformance.simulator_server import ClientInitData, SimulatorServer
 
 
 def initial_setup_for_key_threshold(

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -1,4 +1,4 @@
-from tuf.api.metadata import Timestamp, Snapshot, Root, Targets
+from tuf.api.metadata import Root, Snapshot, Targets, Timestamp
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer

--- a/tuf_conformance/test_updater_key_rotations.py
+++ b/tuf_conformance/test_updater_key_rotations.py
@@ -1,6 +1,5 @@
 import os
 from dataclasses import dataclass
-from typing import Dict
 
 import pytest
 from securesystemslib.signer import CryptoSigner
@@ -88,7 +87,7 @@ root_rotation_cases = {
     ],
 }
 
-non_root_rotation_cases: Dict[str, MdVersion] = {
+non_root_rotation_cases: dict[str, MdVersion] = {
     "1-of-1-key-rotation": MdVersion(keys=[2], threshold=1, sigs=[2]),
     "1-of-1-key-rotation-unused-signatures": MdVersion(
         keys=[1], threshold=1, sigs=[3, 1, 4]

--- a/tuf_conformance/test_updater_key_rotations.py
+++ b/tuf_conformance/test_updater_key_rotations.py
@@ -1,13 +1,13 @@
 import os
-import pytest
-
 from dataclasses import dataclass
-from tuf_conformance.client_runner import ClientRunner
-from tuf_conformance.simulator_server import SimulatorServer
-from securesystemslib.signer import CryptoSigner
 from typing import Dict
 
+import pytest
+from securesystemslib.signer import CryptoSigner
 from tuf.api.metadata import Root
+
+from tuf_conformance.client_runner import ClientRunner
+from tuf_conformance.simulator_server import SimulatorServer
 
 
 @dataclass


### PR DESCRIPTION
* Add half a dozen rulesets to ruffs defaults
* Tighten mypy configuration

I think these are mostly not controversial but the one that might get a debate from some python folks is enforced annotations : I like them and they help me create fewer bugs...