### PR TITLE
Add more basic tests

### DIFF
--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -4,6 +4,8 @@ import subprocess
 from collections.abc import Iterable
 from tempfile import TemporaryDirectory
 
+from tuf.api.exceptions import StorageError
+
 from tuf_conformance.metadata import MetadataTest
 from tuf_conformance.simulator_server import ClientInitData, SimulatorServer
 
@@ -90,9 +92,14 @@ class ClientRunner:
         ]
         return self._run(cmd)
 
-    def version(self, role: str) -> int:
-        """Returns the version of a metadata role"""
-        md = MetadataTest.from_file(os.path.join(self.metadata_dir, f"{role}.json"))
+    def version(self, role: str) -> int | None:
+        """Returns current trusted version of role. Returns None if there is no trusted
+        version
+        """
+        try:
+            md = MetadataTest.from_file(os.path.join(self.metadata_dir, f"{role}.json"))
+        except StorageError:
+            return None
         return md.signed.version
 
     def _files_exist(self, roles: Iterable[str]) -> bool:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -402,9 +402,7 @@ class RepositorySimulator:
 
         # Add targets metadata for all bins.
         for delegated_name in succinct_roles.get_roles():
-            self.mds[delegated_name] = Metadata(
-                Targets(expires=self.safe_expiry)
-            )
+            self.mds[delegated_name] = Metadata(Targets(expires=self.safe_expiry))
 
             self.add_signer(delegated_name, signer)
 

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -75,7 +75,8 @@ class RepositorySimulator:
 
     # pylint: disable=too-many-instance-attributes
     def __init__(self, dump_dir: str | None) -> None:
-        self.md_delegates: dict[str, Metadata[Targets]] = {}
+        # All current metadata
+        self.mds: dict[str, Metadata] = {}
 
         # other metadata is signed on-demand (when fetched) but roots must be
         # explicitly published with publish_root() which maintains this list
@@ -108,25 +109,36 @@ class RepositorySimulator:
 
     @property
     def root(self) -> Root:
-        return self.md_root.signed
+        signed = self.mds[Root.type].signed
+        assert isinstance(signed, Root)
+        return signed
 
     @property
     def timestamp(self) -> Timestamp:
-        return self.md_timestamp.signed
+        signed = self.mds[Timestamp.type].signed
+        assert isinstance(signed, Timestamp)
+        return signed
 
     @property
     def snapshot(self) -> Snapshot:
-        return self.md_snapshot.signed
+        signed = self.mds[Snapshot.type].signed
+        assert isinstance(signed, Snapshot)
+        return signed
 
     @property
     def targets(self) -> Targets:
-        return self.md_targets.signed
+        return self.any_targets("targets")
+
+    def any_targets(self, role: str) -> Targets:
+        signed = self.mds[role].signed
+        assert isinstance(signed, Targets)
+        return signed
 
     def all_targets(self) -> Iterator[tuple[str, Targets]]:
         """Yield role name and signed portion of targets one by one."""
-        yield Targets.type, self.md_targets.signed
-        for role, md in self.md_delegates.items():
-            yield role, md.signed
+        for role, md in self.mds.items():
+            if role not in [Root.type, Timestamp.type, Snapshot.type]:
+                yield role, md.signed
 
     def add_signer(self, role: str, signer: CryptoSigner) -> None:
         if role not in self.signers:
@@ -146,14 +158,14 @@ class RepositorySimulator:
     def _initialize(self) -> None:
         """Setup a minimal valid repository."""
 
-        self.md_targets = MetadataTest(Targets(expires=self.safe_expiry))
-        self.md_snapshot = MetadataTest(Snapshot(expires=self.safe_expiry))
-        self.md_timestamp = MetadataTest(Timestamp(expires=self.safe_expiry))
-        self.md_root = MetadataTest(RootTest(expires=self.safe_expiry))
+        self.mds[Targets.type] = MetadataTest(Targets(expires=self.safe_expiry))
+        self.mds[Snapshot.type] = MetadataTest(Snapshot(expires=self.safe_expiry))
+        self.mds[Timestamp.type] = MetadataTest(Timestamp(expires=self.safe_expiry))
+        self.mds[Root.type] = MetadataTest(RootTest(expires=self.safe_expiry))
 
         for role in TOP_LEVEL_ROLE_NAMES:
             signer = CryptoSigner.generate_ecdsa()
-            self.md_root.signed.add_key(signer.public_key, role)
+            self.root.add_key(signer.public_key, role)
             self.add_signer(role, signer)
 
         self.publish_root()
@@ -167,11 +179,12 @@ class RepositorySimulator:
 
     def publish_root(self) -> None:
         """Sign and store a new serialized version of root."""
-        self.md_root.signatures.clear()
+        root_md = self.mds[Root.type]
+        root_md.signatures.clear()
         for signer in self.signers[Root.type].values():
-            self.md_root.sign(signer, append=True)
+            root_md.sign(signer, append=True)
 
-        self.signed_roots.append(self.md_root.to_bytes(JSONSerializer()))
+        self.signed_roots.append(root_md.to_bytes(JSONSerializer()))
         logger.debug("Published root v%d", self.root.version)
 
     def fetch(self, path: str) -> bytes:
@@ -241,15 +254,7 @@ class RepositorySimulator:
             return self.signed_roots[version - 1]
 
         # sign and serialize the requested metadata
-        md: Metadata | None
-        if role == Timestamp.type:
-            md = self.md_timestamp
-        elif role == Snapshot.type:
-            md = self.md_snapshot
-        elif role == Targets.type:
-            md = self.md_targets
-        else:
-            md = self.md_delegates.get(role)
+        md = self.mds.get(role)
 
         if md is None:
             raise ValueError(f"Unknown role {role}")
@@ -267,14 +272,9 @@ class RepositorySimulator:
         return md.to_bytes(JSONSerializer())
 
     def _version(self, role: str) -> int:
-        if role == Timestamp.type:
-            return self.timestamp.version
-        elif role == Snapshot.type:
-            return self.snapshot.version
-        elif role == Targets.type:
-            return self.targets.version
-        else:
-            return self.root.version
+        signed = self.mds[role].signed
+        assert isinstance(signed, Root | Timestamp | Snapshot | Targets)
+        return signed.version
 
     def _compute_hashes_and_length(self, role: str) -> tuple[dict[str, str], int]:
         data = self.fetch_metadata(role)
@@ -334,23 +334,16 @@ class RepositorySimulator:
             if self.compute_metafile_hashes_length:
                 hashes, length = self._compute_hashes_and_length(role)
 
-            self.md_snapshot.signed.meta[f"{role}.json"] = MetaFile(
+            self.snapshot.meta[f"{role}.json"] = MetaFile(
                 delegate.version, length, hashes
             )
 
         self.snapshot.version -= 1
         self.update_timestamp()
 
-    def _get_delegator(self, delegator_name: str) -> Targets:
-        """Given a delegator name return, its corresponding Targets object."""
-        if delegator_name == Targets.type:
-            return self.targets
-
-        return self.md_delegates[delegator_name].signed
-
     def add_target(self, role: str, data: bytes, path: str) -> None:
         """Create a target from data and add it to the target_files."""
-        targets = self._get_delegator(role)
+        targets = self.any_targets(role)
 
         target = TargetFile.from_data(path, data, ["sha256"])
         targets.targets[path] = target
@@ -360,7 +353,7 @@ class RepositorySimulator:
         self, delegator_name: str, role: DelegatedRole, targets: Targets
     ) -> None:
         """Add delegated target role to the repository."""
-        delegator = self._get_delegator(delegator_name)
+        delegator = self.any_targets(delegator_name)
 
         if (
             delegator.delegations is not None
@@ -382,8 +375,8 @@ class RepositorySimulator:
         self.add_signer(role.name, signer)
 
         # Add metadata for the role
-        if role.name not in self.md_delegates:
-            self.md_delegates[role.name] = Metadata(targets, {})
+        if role.name not in self.mds:
+            self.mds[role.name] = Metadata(targets, {})
 
     def add_succinct_roles(
         self, delegator_name: str, bit_length: int, name_prefix: str
@@ -395,7 +388,7 @@ class RepositorySimulator:
         by succinct roles an empty Targets instance
         is created.
         """
-        delegator = self._get_delegator(delegator_name)
+        delegator = self.any_targets(delegator_name)
 
         if (
             delegator.delegations is not None
@@ -409,7 +402,7 @@ class RepositorySimulator:
 
         # Add targets metadata for all bins.
         for delegated_name in succinct_roles.get_roles():
-            self.md_delegates[delegated_name] = Metadata(
+            self.mds[delegated_name] = Metadata(
                 Targets(expires=self.safe_expiry)
             )
 
@@ -436,11 +429,9 @@ class RepositorySimulator:
             with open(os.path.join(dest_dir, f"{ver}.root.json"), "wb") as f:
                 f.write(self.fetch_metadata(Root.type, ver))
 
-        for role in [Timestamp.type, Snapshot.type, Targets.type]:
-            with open(os.path.join(dest_dir, f"{role}.json"), "wb") as f:
-                f.write(self.fetch_metadata(role))
-
-        for role in self.md_delegates:
+        for role in self.mds:
+            if role == Root.type:
+                continue
             quoted_role = parse.quote(role, "")
             with open(os.path.join(dest_dir, f"{quoted_role}.json"), "wb") as f:
                 f.write(self.fetch_metadata(role))
@@ -449,5 +440,4 @@ class RepositorySimulator:
         """add new key"""
         signer = CryptoSigner.generate_ecdsa()
         self.root.add_key(signer.public_key, role)
-        self.md_root.sign(signer, append=True)
         self.add_signer(role, signer)

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -99,6 +99,28 @@ def test_basic_init_and_refresh(client: ClientRunner, server: SimulatorServer) -
     assert client.version(Snapshot.type) == 1
     assert client.version(Targets.type) == 1
 
+def test_implicit_refresh(client: ClientRunner, server: SimulatorServer) -> None:
+    init_data, repo = server.new_test(client.test_name)
+    assert client.init_client(init_data) == 0
+
+    # Run download immediately after initialization: Expect download to fail
+    # (as targetpath does not exist) but expect metadata to get updated
+    assert client.download_target(init_data,"nonexistent artifact") == 1
+
+    # Verify that expected requests were made
+    assert repo.metadata_statistics == [
+        ("root", 2),
+        ("timestamp", None),
+        ("snapshot", 1),
+        ("targets", 1),
+    ]
+
+    # verify client metadata looks as expected
+    assert client.version(Root.type) == 1
+    assert client.version(Timestamp.type) == 1
+    assert client.version(Snapshot.type) == 1
+    assert client.version(Targets.type) == 1
+
 
 def test_timestamp_eq_versions_check(
     client: ClientRunner, server: SimulatorServer

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -10,6 +10,10 @@ from tuf_conformance.simulator_server import SimulatorServer
 
 
 def test_basic_init_and_refresh(client: ClientRunner, server: SimulatorServer) -> None:
+    """Test basic client functionality.
+
+    Run a refresh, verify client trusted metadata and requests made by the client
+    """
     init_data, repo = server.new_test(client.test_name)
 
     # Run the test: step 1:  initialize client
@@ -34,8 +38,10 @@ def test_basic_init_and_refresh(client: ClientRunner, server: SimulatorServer) -
 
 
 def test_implicit_refresh(client: ClientRunner, server: SimulatorServer) -> None:
-    """Run download immediately after initialization: Expect download to fail
-    (as targetpath does not exist) but expect metadata to get updated
+    """Test that client refreshes metadata before downloading artifacts.
+
+    Run download immediately after initialization: Expect download to fail
+    (as targetpath does not exist) but expect metadata to get updated.
     """
 
     init_data, repo = server.new_test(client.test_name)
@@ -59,7 +65,9 @@ def test_implicit_refresh(client: ClientRunner, server: SimulatorServer) -> None
 
 
 def test_invalid_initial_root(client: ClientRunner, server: SimulatorServer) -> None:
-    """Initialize client with invalid root. Expect refresh to fail and
+    """Test client when initial trusted root is invalid
+
+    Initialize client with invalid root. Expect refresh to fail and
     nothing to get downloaded from repository
     """
     init_data, repo = server.new_test(client.test_name)
@@ -77,7 +85,9 @@ def test_invalid_initial_root(client: ClientRunner, server: SimulatorServer) -> 
 
 
 def test_unsigned_initial_root(client: ClientRunner, server: SimulatorServer) -> None:
-    """Initialize client with root that is not correctly signed. Expect refresh to fail
+    """Test client when initial trusted root is not signed correctly
+
+    Initialize client with root that is not correctly signed. Expect refresh to fail
     and nothing to get downloaded from repository
     """
     init_data, repo = server.new_test(client.test_name)
@@ -113,8 +123,9 @@ unsigned_ids = [case[0] for case in unsigned_cases]
 def test_unsigned_metadata(
     client: ClientRunner, server: SimulatorServer, role: str, trusted_md: dict[str, int]
 ) -> None:
-    """Serve client metadata that is not properly signed.
+    """Test refresh when a top-level role is incorrectly signed.
 
+    Serve client metadata that is not properly signed.
     Expect the refresh to succeed until that point, but not continue from that point.
     """
 

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -108,12 +108,10 @@ unsigned_cases = [
 ]
 unsigned_ids = [case[0] for case in unsigned_cases]
 
+
 @pytest.mark.parametrize("role, trusted_md", unsigned_cases, ids=unsigned_ids)
 def test_unsigned_metadata(
-    client: ClientRunner,
-    server: SimulatorServer,
-    role: str,
-    trusted_md: dict[str, int]
+    client: ClientRunner, server: SimulatorServer, role: str, trusted_md: dict[str, int]
 ) -> None:
     """Serve client metadata that is not properly signed.
 
@@ -125,7 +123,7 @@ def test_unsigned_metadata(
     # remove signing key for role, increase version
     repo.signers[role].popitem()
     repo.mds[role].signed.version += 1
-    if role=="root":
+    if role == "root":
         repo.publish_root()
 
     assert client.init_client(init_data) == 0

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -25,7 +25,7 @@ def test_timestamp_content_changes(
     initial_timestamp_meta_ver = repo.timestamp.snapshot_meta.version
     # Change timestamp without bumping its version in order to test if a new
     # timestamp with the same version will be persisted.
-    repo.md_timestamp.signed.snapshot_meta.version = 100
+    repo.timestamp.snapshot_meta.version = 100
 
     client.refresh(init_data)
 
@@ -51,8 +51,7 @@ def test_new_targets_hash_mismatch(
     # Modify targets contents without updating
     # snapshot's targets hashes
     repo.targets.version += 1
-    targets_version = repo.md_targets.signed.version
-    repo.snapshot.meta["targets.json"].version = targets_version
+    repo.snapshot.meta["targets.json"].version = repo.targets.version
     repo.snapshot.version += 1
     repo.update_timestamp()
 

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -21,7 +21,7 @@ def test_root_expired(client: ClientRunner, server: SimulatorServer) -> None:
     repo.bump_root_by_one()  # v2
     client.refresh(init_data)
 
-    repo.md_root.signed.expires = utils.get_date_n_days_in_past(1)
+    repo.root.expires = utils.get_date_n_days_in_past(1)
     repo.bump_root_by_one()  # v3
     repo.targets.version += 1  # v2
 
@@ -45,7 +45,7 @@ def test_snapshot_expired(client: ClientRunner, server: SimulatorServer) -> None
     # Sanity check
     assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
 
-    repo.md_snapshot.signed.expires = utils.get_date_n_days_in_past(5)
+    repo.snapshot.expires = utils.get_date_n_days_in_past(5)
     repo.update_snapshot()
 
     client.refresh(init_data)
@@ -66,7 +66,7 @@ def test_targets_expired(client: ClientRunner, server: SimulatorServer) -> None:
     client.refresh(init_data)
     assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
 
-    repo.md_targets.signed.expires = utils.get_date_n_days_in_past(5)
+    repo.targets.expires = utils.get_date_n_days_in_past(5)
     repo.update_snapshot()
 
     assert client.init_client(init_data) == 0
@@ -94,7 +94,7 @@ def test_expired_metadata(client: ClientRunner, server: SimulatorServer) -> None
     assert client.init_client(init_data) == 0
 
     now = datetime.datetime.now(timezone.utc)
-    repo.md_timestamp.signed.expires = now + datetime.timedelta(days=7)
+    repo.timestamp.expires = now + datetime.timedelta(days=7)
 
     # Refresh and perform sanity check
     client.refresh(init_data)
@@ -102,10 +102,10 @@ def test_expired_metadata(client: ClientRunner, server: SimulatorServer) -> None
         md = Metadata.from_file(os.path.join(client.metadata_dir, f"{role}.json"))
         assert md.signed.version == 1
 
-    repo.md_targets.signed.version += 1
+    repo.targets.version += 1
     repo.update_snapshot()
 
-    repo.md_timestamp.signed.expires = now + datetime.timedelta(days=21)
+    repo.timestamp.expires = now + datetime.timedelta(days=21)
     repo.update_timestamp()
 
     # Mocking time so that local timestamp has expired

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -10,7 +10,7 @@ def initial_setup_for_key_threshold(
     client: ClientRunner, repo: RepositorySimulator, init_data: ClientInitData
 ) -> None:
     # Explicitly set the threshold
-    repo.md_root.signed.roles[Snapshot.type].threshold = 3
+    repo.root.roles[Snapshot.type].threshold = 3
     repo.bump_root_by_one()  # v2
 
     # Add a legitimate key:
@@ -49,7 +49,6 @@ def test_root_has_keys_but_not_snapshot(
     # Sanity checks
     assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
     assert client.version(Snapshot.type) == 1
-    assert len(repo.md_snapshot.signatures) == 1
 
     initial_setup_for_key_threshold(client, repo, init_data)
 
@@ -90,7 +89,7 @@ def test_wrong_hashing_algorithm(client: ClientRunner, server: SimulatorServer) 
 
     # Increase the threshold but it is met
     assert len(repo.root.roles[Snapshot.type].keyids) == 5
-    repo.md_root.signed.roles[Snapshot.type].threshold = 5
+    repo.root.roles[Snapshot.type].threshold = 5
 
     # Set one of the keys' "keyid_hash_algorithms" to an
     # incorrect algorithm.

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -61,8 +61,8 @@ def test_new_timestamp_snapshot_rollback(
     assert client.refresh(init_data) == 0
 
     # Repo attempts rollback attack
-    repo.md_timestamp.signed.snapshot_meta.version = 1
-    repo.md_snapshot.signed.version = 1
+    repo.timestamp.snapshot_meta.version = 1
+    repo.snapshot.version = 1
     repo.update_timestamp()  # v4
     assert repo._version(Timestamp.type) == 4
     assert client.version(Timestamp.type) == 3
@@ -90,7 +90,7 @@ def test_new_targets_fast_forward_recovery(
     init_data, repo = server.new_test(client.test_name)
     assert client.init_client(init_data) == 0
 
-    repo.md_targets.signed.version = 99999
+    repo.targets.version = 99999
     repo.update_snapshot()  # v2
 
     assert client.refresh(init_data) == 0
@@ -99,7 +99,7 @@ def test_new_targets_fast_forward_recovery(
     repo.rotate_keys(Snapshot.type)
     repo.bump_root_by_one()
 
-    repo.md_targets.signed.version = 1
+    repo.targets.version = 1
     repo.update_snapshot()  # v3
 
     client.refresh(init_data)
@@ -183,7 +183,7 @@ def test_new_timestamp_fast_forward_recovery(
     # rolls back timestamp version
     repo.rotate_keys(Timestamp.type)
     repo.bump_root_by_one()
-    repo.md_timestamp.signed.version = 1
+    repo.timestamp.version = 1
 
     # client refresh the metadata and see the initial timestamp version
     client.refresh(init_data)
@@ -204,7 +204,7 @@ def test_snapshot_rollback_with_local_snapshot_hash_mismatch(
 
     # Initialize all metadata and assign targets
     # version higher than 1.
-    repo.md_targets.signed.version = 2
+    repo.targets.version = 2
     repo.update_snapshot()
     assert client.refresh(init_data) == 0
     assert client.version(Targets.type) == 2


### PR DESCRIPTION
1. This adds a bunch of basic tests -- something I think new clients should start with solving.
2. This also tries to cleanup the metadata access in RepositorySimulator:
   * avoid metadata access when the typed property is shorter and makes sense:  use `repo.timestamp.version` instead of `repo.md_timestamp.signed.version`
   * Store all metadata in a single dict: this way we don't need to have a five-way if-clause when we just need to access the role by name (which is the usual case in parametrized tests)
   * Try to provide easy accessors for typical cases (`repo.timestamp`, `repo.any_targets(role)`, etc)
   
I can separate the two if the review is annoying as is