### PR TITLE
Add unusual rolename tests

### DIFF
--- a/clients/python-tuf/python_tuf.py
+++ b/clients/python-tuf/python_tuf.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 import argparse
+import logging
 import os
 import shutil
 import sys
@@ -61,6 +62,7 @@ def main() -> int:
     parser.add_argument("--target-name", required=False)
     parser.add_argument("--target-dir", required=False)
     parser.add_argument("--target-base-url", required=False)
+    parser.add_argument("-v", "--verbose", action="count", default=0)
 
     sub_command = parser.add_subparsers(dest="sub_command")
     init_parser = sub_command.add_parser(
@@ -80,6 +82,15 @@ def main() -> int:
     )
 
     command_args = parser.parse_args()
+
+    if command_args.verbose <= 1:
+        loglevel = logging.WARNING
+    elif command_args.verbose == 2:
+        loglevel = logging.INFO
+    else:
+        loglevel = logging.DEBUG
+
+    logging.basicConfig(level=loglevel)
 
     # initialize the TUF Client Example infrastructure
     if command_args.sub_command == "init":

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from tempfile import TemporaryDirectory
 
 from tuf.api.exceptions import StorageError
+from tuf.api.metadata import Metadata
 
 from tuf_conformance.metadata import MetadataTest
 from tuf_conformance.simulator_server import ClientInitData, SimulatorServer
@@ -76,6 +77,7 @@ class ClientRunner:
         return self._run(cmd)
 
     def download_target(self, data: ClientInitData, target_name: str) -> int:
+        self._server.debug_dump(self.test_name)
         cmd = [
             *self._cmd,
             "--metadata-url",
@@ -110,7 +112,17 @@ class ClientRunner:
         local_metadata_files = sorted(os.listdir(self.metadata_dir))
         return all(x in local_metadata_files for x in expected_files)
 
-    def _content(self, role: str) -> bytes:
-        """Return role metadata as bytes"""
-        with open(os.path.join(self.metadata_dir, f"{role}.json"), "rb") as f:
-            return f.read()
+    def trusted_roles(self) -> dict[str, int]:
+        """Return dict of current trusted role names and versions
+
+        Note that delegated role names may be encoded in a application specific way"""
+        roles = {}
+        for filename in sorted(os.listdir(self.metadata_dir)):
+            if not filename.endswith(".json"):
+                continue
+            rolename = filename.removesuffix(".json")
+            md = Metadata.from_file(os.path.join(self.metadata_dir, filename))
+            roles[rolename] = md.signed.version
+
+        return roles
+

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -125,4 +125,3 @@ class ClientRunner:
             roles[rolename] = md.signed.version
 
         return roles
-

--- a/tuf_conformance/test_quoting_issues.py
+++ b/tuf_conformance/test_quoting_issues.py
@@ -1,0 +1,48 @@
+from urllib import parse
+
+import pytest
+from tuf.api.metadata import DelegatedRole, Targets
+
+from tuf_conformance.client_runner import ClientRunner
+from tuf_conformance.simulator_server import SimulatorServer
+
+# tuple of
+#  * name of delegated role,
+#  * do we expect the role to be found in client trusted roles
+unusual_role_names = [
+    "?",
+    "#",
+    "/delegatedrole",
+    "../delegatedrole",
+]
+
+
+@pytest.mark.parametrize("role", unusual_role_names)
+def test_unusual_role_name(
+    client: ClientRunner, server: SimulatorServer, role: str
+) -> None:
+    """Test various unusual rolenames
+
+    Role names are used in http requests and potentially file names:
+    verify that both uses seem safe.
+    """
+    init_data, repo = server.new_test(client.test_name)
+
+    # Add a delegation
+    delegated_role = DelegatedRole(role, [], 1, False, ["*"])
+    delegated_targets = Targets(1, None, repo.safe_expiry, {}, None)
+    repo.add_delegation(Targets.type, delegated_role, delegated_targets)
+
+    # Add signer, add the key to roles delegation
+    repo.add_key(role, Targets.type)
+
+    repo.targets.version += 1
+    repo.update_snapshot()
+
+    client.init_client(init_data)
+    assert client.download_target(init_data, "nonexistent target") == 1
+
+    # Make sure the correctly quoted request was made
+    assert (parse.quote(role, ""), 1) in repo.metadata_statistics
+    # count trusted roles (don't check name since we do not know how client encodes it)
+    assert len(client.trusted_roles()) == 5


### PR DESCRIPTION
These tests are useful in codifying some expectations on how to handle weird rolenames. I wouldn't be surprised if some clients want to skip this test but the `"../delegatedrole"` case comes from an actual security issue we've had (file traversal when storing the metadata).


This also enables #137  although I did not replace usage of `_file_exist()` yet -- I'm not sure if the new  `trusted_roles(self)` is the right API: maybe it should be sorted by mtime instead of alpha?