### PR TITLE
Use --repository-dump-dir in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ifndef FAKETIME
 	$(error "Program 'faketime' was not found. Please install it")
 endif
 
+DUMP_DIR = /tmp/tuf-conformance-dump
 
 #########################
 # tuf-conformance section
@@ -48,7 +49,10 @@ fix: dev
 
 PHONY: test-python-tuf
 test-python-tuf: dev faketime
-	./env/bin/pytest tuf_conformance --entrypoint "./env/bin/python ./clients/python-tuf/python_tuf.py" -vv
+	./env/bin/pytest tuf_conformance \
+		--entrypoint "./env/bin/python ./clients/python-tuf/python_tuf.py" \
+		--repository-dump-dir $(DUMP_DIR)
+	@echo Repository dump in $(DUMP_DIR)
 
 #########################
 # go-tuf section
@@ -56,8 +60,10 @@ test-python-tuf: dev faketime
 
 PHONY: test-go-tuf
 test-go-tuf: dev build-go-tuf faketime
-	./env/bin/pytest tuf_conformance --entrypoint "./clients/go-tuf/go-tuf"
-
+	./env/bin/pytest tuf_conformance \
+		--entrypoint "./clients/go-tuf/go-tuf" \
+		--repository-dump-dir $(DUMP_DIR)
+	@echo Repository dump in $(DUMP_DIR)
 PHONY: build-go-tuf
 build-go-tuf:
 	cd ./clients/go-tuf && go build .


### PR DESCRIPTION
This intends to to standardize the the way we invoke the suite: Makefile and GitHub action should, when possible, use the same options.

This does not try to wipe the previous dump contents if any exist: this could lead to unexpected dump dir contents when tests are modified and re-run: this does not affect the test suite and is solved by deleting the directory and re-running tests.

---

@AdamKorcz I think you wanted something like this, let me know if anything is missing