### PR TITLE
Use trusted_roles()

### DIFF
--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -104,16 +104,8 @@ class ClientRunner:
             return None
         return md.signed.version
 
-    def _files_exist(self, roles: Iterable[str]) -> bool:
-        """Check that local metadata files exist for 'roles'.
-        There may be additional files in the local
-        metadata_dir than the expted files"""
-        expected_files = sorted([f"{role}.json" for role in roles])
-        local_metadata_files = sorted(os.listdir(self.metadata_dir))
-        return all(x in local_metadata_files for x in expected_files)
-
     def trusted_roles(self) -> list[tuple[str, int]]:
-        """Return dict of current trusted role names and versions
+        """Return list of current trusted role names and versions
 
         Note that delegated role names may be encoded in a application specific way"""
         roles = []

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import subprocess
-from collections.abc import Iterable
 from tempfile import TemporaryDirectory
 
 from tuf.api.exceptions import StorageError

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -111,17 +111,17 @@ def test_unsigned_initial_root(client: ClientRunner, server: SimulatorServer) ->
 #  * rolename that will be improperly signed
 #  * expected trusted metadata versions after refresh fails
 unsigned_cases = [
-    ("root", {"root": 1, "timestamp": None, "snapshot": None, "targets": None}),
-    ("timestamp", {"root": 1, "timestamp": None, "snapshot": None, "targets": None}),
-    ("snapshot", {"root": 1, "timestamp": 1, "snapshot": None, "targets": None}),
-    ("targets", {"root": 1, "timestamp": 1, "snapshot": 1, "targets": None}),
+    ("root", [("root", 1)]),
+    ("timestamp", [("root", 1)]),
+    ("snapshot", [("root", 1), ("timestamp", 1)]),
+    ("targets", [("root", 1), ("snapshot", 1), ("timestamp", 1)]),
 ]
 unsigned_ids = [case[0] for case in unsigned_cases]
 
 
-@pytest.mark.parametrize("role, trusted_md", unsigned_cases, ids=unsigned_ids)
+@pytest.mark.parametrize("role, trusted", unsigned_cases, ids=unsigned_ids)
 def test_unsigned_metadata(
-    client: ClientRunner, server: SimulatorServer, role: str, trusted_md: dict[str, int]
+    client: ClientRunner, server: SimulatorServer, role: str, trusted: tuple[str, int]
 ) -> None:
     """Test refresh when a top-level role is incorrectly signed.
 
@@ -141,9 +141,7 @@ def test_unsigned_metadata(
 
     # Verify that refresh fails and that current trusted metadata is as expected
     assert client.refresh(init_data) == 1
-    for trusted_role, ver in trusted_md.items():
-        assert client.version(trusted_role) == ver
-
+    assert client.trusted_roles() == trusted
 
 def test_timestamp_content_changes(
     client: ClientRunner, server: SimulatorServer
@@ -156,8 +154,6 @@ def test_timestamp_content_changes(
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
-    # Sanity check
-    assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
 
     initial_timestamp_meta_ver = repo.timestamp.snapshot_meta.version
     # Change timestamp without bumping its version in order to test if a new
@@ -177,8 +173,6 @@ def test_new_targets_hash_mismatch(
 
     assert client.init_client(init_data) == 0
     client.refresh(init_data)
-    # Sanity check
-    assert client._files_exist([Root.type, Timestamp.type, Snapshot.type])
 
     repo.compute_metafile_hashes_length = True
     repo.update_snapshot()
@@ -200,17 +194,19 @@ def test_new_targets_hash_mismatch(
 def test_new_targets_version_mismatch(
     client: ClientRunner, server: SimulatorServer
 ) -> None:
-    # Check against snapshot role's targets version
+    """Create new targets version. Check that client does not
+    download it as the version is not in snapshot.meta
+    """
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
-    assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
+    assert client.refresh(init_data) == 0
 
     repo.targets.version += 1
-    client.refresh(init_data)
-    # Check that the client still has the correct metadata files
-    assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
+    assert client.refresh(init_data) == 0
+    # Check that the client still has the correct targets version
+    assert client.version(Targets.type) == 1
+    assert repo.metadata_statistics[-1] == (Timestamp.type, None)
 
 
 def test_timestamp_eq_versions_check(

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -143,6 +143,7 @@ def test_unsigned_metadata(
     assert client.refresh(init_data) == 1
     assert client.trusted_roles() == trusted
 
+
 def test_timestamp_content_changes(
     client: ClientRunner, server: SimulatorServer
 ) -> None:

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -1,8 +1,7 @@
 import datetime
-import os
 from datetime import timezone
 
-from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
+from tuf.api.metadata import Root, Snapshot, Targets, Timestamp
 
 from tuf_conformance import utils
 from tuf_conformance.client_runner import ClientRunner
@@ -57,6 +56,7 @@ def test_snapshot_expired(client: ClientRunner, server: SimulatorServer) -> None
         (Targets.type, 1),
         (Timestamp.type, 2),
     ]
+
 
 def test_targets_expired(client: ClientRunner, server: SimulatorServer) -> None:
     """Tests a case where the targets metadata is expired.

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -1,5 +1,5 @@
 from securesystemslib.signer import CryptoSigner
-from tuf.api.metadata import Root, Snapshot, Targets, Timestamp
+from tuf.api.metadata import Root, Snapshot
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.repository_simulator import RepositorySimulator

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -45,10 +45,7 @@ def test_root_has_keys_but_not_snapshot(
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
-    # Sanity checks
-    assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
-    assert client.version(Snapshot.type) == 1
+    assert client.refresh(init_data) == 0
 
     initial_setup_for_key_threshold(client, repo, init_data)
 
@@ -56,12 +53,14 @@ def test_root_has_keys_but_not_snapshot(
     repo.root.roles[Snapshot.type].threshold = 5
     repo.bump_root_by_one()  # v5
 
-    # Updating should fail. Root should bump, but not snapshot
+    # Refresh should fail: root updates but there's no new snapshot:
+    # The existing snapshot does not meet threshold anymore.
+    # NOTE: we don't actually expect clients to delete the
+    # file from trusted_roles() at this point
     assert client.refresh(init_data) == 1
     assert client.version(Root.type) == 5
-    assert client.version(Snapshot.type) == 3
 
-    # Add two invalid keys only to root and expect the client
+    # Add two keyids only to root and expect the client
     # to fail updating
     signer = CryptoSigner.generate_ecdsa()
 
@@ -137,16 +136,14 @@ def test_snapshot_threshold(client: ClientRunner, server: SimulatorServer) -> No
 
 
 def test_duplicate_keys_root(client: ClientRunner, server: SimulatorServer) -> None:
-    # Set/keep a threshold of 10 keys. All the keyids are different,
-    # but the keys are all identical. As such, the snapshot metadata
-    # has been signed by 1 key.
+    """Test multiple identical keyids, try to fake threshold
+
+    Client should either not accept metadata with duplicate keyids in a role,
+    or it should not allow the duplicate keyids to count in threshold calculation
+    """
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
-    # Sanity checks
-    assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
-    assert client.version(Snapshot.type) == 1
 
     signer = CryptoSigner.generate_ecdsa()
 
@@ -156,27 +153,15 @@ def test_duplicate_keys_root(client: ClientRunner, server: SimulatorServer) -> N
 
     repo.add_signer(Snapshot.type, signer)
 
-    repo.bump_root_by_one()
-    assert len(repo.root.roles["snapshot"].keyids) == 10
-
     # Set a threshold that will be covered but only by
     # the same key multiple times and not separate keys.
     repo.root.roles[Snapshot.type].threshold = 6
     repo.bump_root_by_one()
 
-    repo.update_timestamp()
-    repo.update_snapshot()  # v2
-
-    # Sanity check that the clients snapshot
-    # metadata is version 1
-    assert client.version(Snapshot.type) == 1
-
-    # This should fail because the metadata should not have
-    # the same key in more than 1 keyids. We check failure
-    # here, and further down we check that the clients
-    # metadata has not been updated.
+    # This should fail for one of two reasons:
+    # 1. client does not accept root v2 metadata that contains duplicate keyids or
+    # 2. client did accept root v2 but then snapshot threshold is not reached
     assert client.refresh(init_data) == 1
 
-    # The clients snapshot metadata should still
-    # be version 1
-    assert client.version(Snapshot.type) == 1
+    # client should not have accepted snapshot
+    assert client.version(Snapshot.type) is None

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -164,9 +164,8 @@ def test_new_snapshot_version_mismatch(
 ) -> None:
     """Tests that the client does not download the snapshot
     metadata if the repo has bumped the snapshot version in
-    the snapshot metadata but not in the timestamp.
-    The client should have only root and timestamp
-    when it refreshes."""
+    the snapshot metadata but not in timestamp.meta.
+    """
 
     init_data, repo = server.new_test(client.test_name)
 
@@ -176,7 +175,7 @@ def test_new_snapshot_version_mismatch(
     repo.snapshot.version += 1
 
     assert client.refresh(init_data) == 1
-    assert client._files_exist([Root.type, Timestamp.type])
+    assert client.trusted_roles() == [(Root.type, 1), (Timestamp.type, 1)]
     assert repo.metadata_statistics[-1] == (Snapshot.type, 1)
 
 
@@ -221,8 +220,6 @@ def test_snapshot_rollback_with_local_snapshot_hash_mismatch(
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
-    assert client._files_exist([Root.type, Timestamp.type, Snapshot.type, Targets.type])
 
     # Initialize all metadata and assign targets
     # version higher than 1.


### PR DESCRIPTION
* Use the new `trusted_roles()` or` version()` instead of `_files_exist()` which was a bit vague
* Improve comments nearby these calls
* Remove nearby refresh() calls, repository changes and asserts that did not actually make the tests more useful
* Fix a few small bugs that got revealed