### PR TITLE
Static tests

### DIFF
--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -8,7 +8,11 @@ from tuf.api.exceptions import StorageError
 from tuf.api.metadata import Metadata
 
 from tuf_conformance.metadata import MetadataTest
-from tuf_conformance.simulator_server import ClientInitData, SimulatorServer
+from tuf_conformance.simulator_server import (
+    ClientInitData,
+    SimulatorServer,
+    StaticServer,
+)
 
 
 class ClientRunner:
@@ -20,7 +24,7 @@ class ClientRunner:
     ClientRunner manages client resources (like the cache paths etc)"""
 
     def __init__(
-        self, client_cmd: str, server: SimulatorServer, test_name: str
+        self, client_cmd: str, server: SimulatorServer | StaticServer, test_name: str
     ) -> None:
         self._server = server
         self._cmd = client_cmd.split(" ")

--- a/tuf_conformance/static_data/README.md
+++ b/tuf_conformance/static_data/README.md
@@ -1,0 +1,13 @@
+## Static test data from actual repository implementations
+
+Subdirectories should contain complete repositories produced by a specific repository
+implementation. Each repository in a `<SUBDIR>` should
+* demonstrate all of the TUF features that the implementation uses
+* not expire for a very long time
+* Store metadata in `<SUBDIR/metadata>` and artifacts in `<SUBDIR/targets>` 
+* be ready to be published with just `python -m http.server <SUBDIR>` (in other words filenames
+  should match the TUF http API)
+
+Additionally there should be 
+  * A version of root in `<SUBDIR>/initial_root.json`: This will be used to initialize the client
+  * `<SUBDIR>/targetpath` containing a targetpath of an artifact that exists in the repository

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/README.md
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/README.md
@@ -1,0 +1,10 @@
+This is a repository created with tuf-on-ci 0.11 in
+https://github.com/jku/test-data-for-tuf-conformance.
+
+Notes:
+* Contains Yubikey and Google Cloud KMS keys (both in practice ecdsa keys)
+* There's one delegated targets role with one artifact
+* "Unsigned" keys have an empty signature string in signatures
+* The metadata contains custom fields in keys and roles
+* Should stay valid until 2044
+* There are a few additional files in the metadata dir (index.html, index.md)

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/initial_root.json
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/initial_root.json
@@ -1,0 +1,65 @@
+{
+ "signatures": [
+  {
+   "keyid": "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81",
+   "sig": "3045022100e691c6fa8f401a7f6cb6f2fbf5d2596bf50755acdc95d53bbac1bb7f5c2d6bfc02206a85c8ea8015a63d9903588b3bbc5bd563e043cf43fc1b9198a9112e15f2df53"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2044-08-10T10:05:04Z",
+  "keys": {
+   "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu+ebm3VUg6U2b0IIeR6NFZU7uxkL\nR1sVLxV8SEW7G+AMXMasEQf5daxfwVMP1kuEkhGs3mBYLkYXlWDh9BNSxg==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-online-uri": "gcpkms:projects/python-tuf-kms/locations/global/keyRings/git-repo-demo/cryptoKeys/online/cryptoKeyVersions/1"
+   },
+   "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEohqIdE+yTl4OxpX8ZxNUPrg3SL9H\nBDnhZuceKkxy2oMhUOxhWweZeG3bfM1T4ZLnJimC6CAYVU5+F5jZCoftRw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@jku"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7300,
+    "x-tuf-on-ci-signing-period": 60
+   },
+   "targets": {
+    "keyids": [
+     "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7300,
+    "x-tuf-on-ci-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1,
+  "x-tuf-on-ci-expiry-period": 7300,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/1.root.json
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/1.root.json
@@ -1,0 +1,65 @@
+{
+ "signatures": [
+  {
+   "keyid": "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81",
+   "sig": "3045022100e691c6fa8f401a7f6cb6f2fbf5d2596bf50755acdc95d53bbac1bb7f5c2d6bfc02206a85c8ea8015a63d9903588b3bbc5bd563e043cf43fc1b9198a9112e15f2df53"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2044-08-10T10:05:04Z",
+  "keys": {
+   "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu+ebm3VUg6U2b0IIeR6NFZU7uxkL\nR1sVLxV8SEW7G+AMXMasEQf5daxfwVMP1kuEkhGs3mBYLkYXlWDh9BNSxg==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-online-uri": "gcpkms:projects/python-tuf-kms/locations/global/keyRings/git-repo-demo/cryptoKeys/online/cryptoKeyVersions/1"
+   },
+   "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEohqIdE+yTl4OxpX8ZxNUPrg3SL9H\nBDnhZuceKkxy2oMhUOxhWweZeG3bfM1T4ZLnJimC6CAYVU5+F5jZCoftRw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@jku"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7300,
+    "x-tuf-on-ci-signing-period": 60
+   },
+   "targets": {
+    "keyids": [
+     "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7300,
+    "x-tuf-on-ci-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1,
+  "x-tuf-on-ci-expiry-period": 7300,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/1.targets.json
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/1.targets.json
@@ -1,0 +1,54 @@
+{
+ "signatures": [
+  {
+   "keyid": "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81",
+   "sig": "3044022027258898a89d38218fce7212c24659ec771105a3532d38ea4ef0d2fb84d9e7ff02206e086d154e3cba72e9c55941d85c61f74eb425e2e90e308636bb1883287290c0"
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "delegations": {
+   "keys": {
+    "01104111d18f559cd1ca33a2dd91a2100f2812ffe02c9f70a0e5c4d915b453ac": {
+     "keytype": "ecdsa",
+     "keyval": {
+      "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1wgTb0BVTvCiDlaPmnUfXOLubQMj\nUxjiafwKLMgiRD0fK+XLSKK6fJjrzNkZCIYG78AUmhbRskgJgOatWD+Z9w==\n-----END PUBLIC KEY-----\n"
+     },
+     "scheme": "ecdsa-sha2-nistp256",
+     "x-tuf-on-ci-keyowner": "@-test-user-"
+    },
+    "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81": {
+     "keytype": "ecdsa",
+     "keyval": {
+      "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEohqIdE+yTl4OxpX8ZxNUPrg3SL9H\nBDnhZuceKkxy2oMhUOxhWweZeG3bfM1T4ZLnJimC6CAYVU5+F5jZCoftRw==\n-----END PUBLIC KEY-----\n"
+     },
+     "scheme": "ecdsa-sha2-nistp256",
+     "x-tuf-on-ci-keyowner": "@jku"
+    }
+   },
+   "roles": [
+    {
+     "keyids": [
+      "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81",
+      "01104111d18f559cd1ca33a2dd91a2100f2812ffe02c9f70a0e5c4d915b453ac"
+     ],
+     "name": "delegatedrole",
+     "paths": [
+      "delegatedrole/*",
+      "delegatedrole/*/*",
+      "delegatedrole/*/*/*",
+      "delegatedrole/*/*/*/*"
+     ],
+     "terminating": true,
+     "threshold": 1
+    }
+   ]
+  },
+  "expires": "2044-08-10T10:09:31Z",
+  "spec_version": "1.0.31",
+  "targets": {},
+  "version": 1,
+  "x-tuf-on-ci-expiry-period": 7300,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/2.delegatedrole.json
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/2.delegatedrole.json
@@ -1,0 +1,28 @@
+{
+ "signatures": [
+  {
+   "keyid": "aa61e09f6af7662ac686cf0c6364079f63d3e7a86836684eeced93eace3acd81",
+   "sig": "30440220396123e307132efdc6910ab3a82a1106d98f8720be7bd4c86ac9481c622d531f02207467ef8d27c9f7bae24c09c7392dfde1b0ad818c96fac1f413f290327611a07d"
+  },
+  {
+   "keyid": "01104111d18f559cd1ca33a2dd91a2100f2812ffe02c9f70a0e5c4d915b453ac",
+   "sig": ""
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "expires": "2044-08-10T10:18:49Z",
+  "spec_version": "1.0.31",
+  "targets": {
+   "delegatedrole/artifact": {
+    "hashes": {
+     "sha256": "45f337ee451b4c098d121d09cc224bacc7794503ac58a47a78cfe7ebefb7fab3"
+    },
+    "length": 34
+   }
+  },
+  "version": 2,
+  "x-tuf-on-ci-expiry-period": 7300,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/2.snapshot.json
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/2.snapshot.json
@@ -1,0 +1,22 @@
+{
+ "signatures": [
+  {
+   "keyid": "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777",
+   "sig": "304502202009fa4afd2f4fbad523ebafcc5d22deb3428753c384395147f88265d6ec6f900221009298a6361fcdc1f3226b2f7e8aa056eccd4697ad8077d633f1c17b09f724dd8a"
+  }
+ ],
+ "signed": {
+  "_type": "snapshot",
+  "expires": "2044-08-10T10:21:51Z",
+  "meta": {
+   "delegatedrole.json": {
+    "version": 2
+   },
+   "targets.json": {
+    "version": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 2
+ }
+}

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/index.html
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Begin Jekyll SEO tag v2.8.0 -->
+<title>TUF Repository state | test-data-for-tuf-conformance</title>
+<meta name="generator" content="Jekyll v3.9.5" />
+<meta property="og:title" content="TUF Repository state" />
+<meta property="og:locale" content="en_US" />
+<link rel="canonical" href="https://jku.github.io/test-data-for-tuf-conformance/metadata/" />
+<meta property="og:url" content="https://jku.github.io/test-data-for-tuf-conformance/metadata/" />
+<meta property="og:site_name" content="test-data-for-tuf-conformance" />
+<meta property="og:type" content="website" />
+<meta name="twitter:card" content="summary" />
+<meta property="twitter:title" content="TUF Repository state" />
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"WebPage","headline":"TUF Repository state","url":"https://jku.github.io/test-data-for-tuf-conformance/metadata/"}</script>
+<!-- End Jekyll SEO tag -->
+
+    <link rel="stylesheet" href="/test-data-for-tuf-conformance/assets/css/style.css?v=b35b723fb8e5602d056c3f99da586b3341f6fbd0">
+    <!-- start custom head snippets, customize with your own _includes/head-custom.html file -->
+
+<!-- Setup Google Analytics -->
+
+
+
+<!-- You can set your favicon here -->
+<!-- link rel="shortcut icon" type="image/x-icon" href="/test-data-for-tuf-conformance/favicon.ico" -->
+
+<!-- end custom head snippets -->
+
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      
+      <h1><a href="https://jku.github.io/test-data-for-tuf-conformance/">test-data-for-tuf-conformance</a></h1>
+      
+
+      <h2 id="tuf-repository-state">TUF Repository state</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>Next signing</th>
+      <th>Signers</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>root (<a href="1.root.json">json</a>)</td>
+      <td><a href="##" title="2044-06-11 10:05:04 - 2044-08-10 10:05:04">Starts 2044-06-11</a></td>
+      <td>@jku (1 of 1 required)</td>
+    </tr>
+    <tr>
+      <td>timestamp (<a href="timestamp.json">json</a>)</td>
+      <td><a href="##" title="2044-08-09 10:21:51 - 2044-08-10 10:21:51">Starts 2044-08-09</a></td>
+      <td><em>online key</em> (1 of 1 required)</td>
+    </tr>
+    <tr>
+      <td>snapshot (<a href="2.snapshot.json">json</a>)</td>
+      <td><a href="##" title="2044-06-11 10:21:51 - 2044-08-10 10:21:51">Starts 2044-06-11</a></td>
+      <td><em>online key</em> (1 of 1 required)</td>
+    </tr>
+    <tr>
+      <td>targets (<a href="1.targets.json">json</a>)</td>
+      <td><a href="##" title="2044-06-11 10:09:31 - 2044-08-10 10:09:31">Starts 2044-06-11</a></td>
+      <td>@jku (1 of 1 required)</td>
+    </tr>
+    <tr>
+      <td>delegatedrole (<a href="2.delegatedrole.json">json</a>)</td>
+      <td><a href="##" title="2044-06-11 10:18:49 - 2044-08-10 10:18:49">Starts 2044-06-11</a></td>
+      <td>@jku, @-test-user- (1 of 2 required)</td>
+    </tr>
+  </tbody>
+</table>
+
+<p><em>Generated 2024-08-15T10:22+00:00 from
+<a href="https://github.com/jku/test-data-for-tuf-conformance">test-data-for-tuf-conformance</a> commit <a href="https://github.com/jku/test-data-for-tuf-conformance/tree/b35b723fb8e5602d056c3f99da586b3341f6fbd0">b35b723</a>
+by <a href="https://github.com/theupdateframework/tuf-on-ci">TUF-on-CI</a> v0.11.0.</em></p>
+
+
+      
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
+    <script>anchors.add();</script>
+  </body>
+</html>

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/index.md
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/index.md
@@ -1,0 +1,13 @@
+## TUF Repository state
+
+| Role | Next signing | Signers |
+| - | - | - |
+| root (<a href="1.root.json">json</a>) | [Starts 2044-06-11](## '2044-06-11 10:05:04 - 2044-08-10 10:05:04') | @jku (1 of 1 required) |
+| timestamp (<a href="timestamp.json">json</a>) | [Starts 2044-08-09](## '2044-08-09 10:21:51 - 2044-08-10 10:21:51') | _online key_ (1 of 1 required) |
+| snapshot (<a href="2.snapshot.json">json</a>) | [Starts 2044-06-11](## '2044-06-11 10:21:51 - 2044-08-10 10:21:51') | _online key_ (1 of 1 required) |
+| targets (<a href="1.targets.json">json</a>) | [Starts 2044-06-11](## '2044-06-11 10:09:31 - 2044-08-10 10:09:31') | @jku (1 of 1 required) |
+| delegatedrole (<a href="2.delegatedrole.json">json</a>) | [Starts 2044-06-11](## '2044-06-11 10:18:49 - 2044-08-10 10:18:49') | @jku, @-test-user- (1 of 2 required) |
+
+_Generated 2024-08-15T10:22+00:00 from
+[test-data-for-tuf-conformance](https://github.com/jku/test-data-for-tuf-conformance) commit [b35b723](https://github.com/jku/test-data-for-tuf-conformance/tree/b35b723fb8e5602d056c3f99da586b3341f6fbd0)
+by [TUF-on-CI](https://github.com/theupdateframework/tuf-on-ci) v0.11.0._

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/timestamp.json
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/metadata/timestamp.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "a54e905f3e03bb0cccdc954bd40d4d29b5c1a2a95c2777f10f9c63a503c7f777",
+   "sig": "304402200168ff4eda848db6b7719b721279c9fe1c2573a2dbc2bfcd49e8cfe73033dfd40220782d2445c6d5ab914f7d4bca14ae6016bbb0b76ef7ba571343decff172c65df6"
+  }
+ ],
+ "signed": {
+  "_type": "timestamp",
+  "expires": "2044-08-10T10:21:51Z",
+  "meta": {
+   "snapshot.json": {
+    "version": 2
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 2
+ }
+}

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/targetpath
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/targetpath
@@ -1,0 +1,1 @@
+delegatedrole/artifact

--- a/tuf_conformance/static_data/tuf-on-ci-0.11/targets/delegatedrole/45f337ee451b4c098d121d09cc224bacc7794503ac58a47a78cfe7ebefb7fab3.artifact
+++ b/tuf_conformance/static_data/tuf-on-ci-0.11/targets/delegatedrole/45f337ee451b4c098d121d09cc224bacc7794503ac58a47a78cfe7ebefb7fab3.artifact
@@ -1,0 +1,1 @@
+artifact for tuf-on-ci repository

--- a/tuf_conformance/test_static_repositories.py
+++ b/tuf_conformance/test_static_repositories.py
@@ -1,0 +1,22 @@
+import os
+
+import pytest
+
+from tuf_conformance.client_runner import ClientRunner
+from tuf_conformance.simulator_server import StaticServer
+
+static_repos = []
+for static_dir in os.listdir(os.path.join("tuf_conformance", "static_data")):
+    if os.path.isdir(os.path.join("tuf_conformance", "static_data", static_dir)):
+        static_repos.append(static_dir)
+
+
+@pytest.mark.parametrize("static_repo", static_repos)
+def test_static_repo(
+    static_client: ClientRunner, static_server: StaticServer, static_repo: str
+) -> None:
+    init_data, targetpath = static_server.new_test(static_repo)
+
+    assert static_client.init_client(init_data) == 0
+    assert static_client.refresh(init_data) == 0
+    assert static_client.download_target(init_data, targetpath) == 0

--- a/tuf_conformance/test_static_repositories.py
+++ b/tuf_conformance/test_static_repositories.py
@@ -12,9 +12,14 @@ for static_dir in os.listdir(os.path.join("tuf_conformance", "static_data")):
 
 
 @pytest.mark.parametrize("static_repo", static_repos)
-def test_static_repo(
+def test_static_repository(
     static_client: ClientRunner, static_server: StaticServer, static_repo: str
 ) -> None:
+    """Test static repositories stored in tuf_conformance/static_data/
+
+    This test is not a specification compliance test: It tests client compatibility
+    with the repository format that a specific repository implementation produces.
+    """
     init_data, targetpath = static_server.new_test(static_repo)
 
     assert static_client.init_client(init_data) == 0


### PR DESCRIPTION
* Add some infrastructure support for testing static repositories: I may have gone overkill but I made the same kind of setup as the simulated repositories have (so a client fixture and server fixture). ClientRunner works with both.
* The end result is that the test itself requires no changes when new static data is added: Just add the repository content into a sub directory of `tuf_conformance/static_data` and it will be treated as a new test
* Add test data for tuf-on-ci: the idea is that the metadata is mostly fire-and-forget -- once it's committed it stays there or we just wipe it and replace with something new
* The tested surface could be increased: currently there is a single targetpath that is expected to successfully download 

@kairoaraujo I'm planning this sort of setup for some practical compatibility tests -- so repository software developers (or specific repository maintainers) can provide example data that clients can test against. Let me know if you have comments