### PR TITLE
Change default keytype to RSA

### DIFF
--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -151,7 +151,7 @@ class RepositorySimulator:
         self.root.roles[role].keyids.clear()
         self.signers[role].clear()
         for _ in range(0, self.root.roles[role].threshold):
-            signer = CryptoSigner.generate_ecdsa()
+            signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
             self.root.add_key(signer.public_key, role)
             self.add_signer(role, signer)
 
@@ -164,7 +164,7 @@ class RepositorySimulator:
         self.mds[Root.type] = MetadataTest(RootTest(expires=self.safe_expiry))
 
         for role in TOP_LEVEL_ROLE_NAMES:
-            signer = CryptoSigner.generate_ecdsa()
+            signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
             self.root.add_key(signer.public_key, role)
             self.add_signer(role, signer)
 
@@ -338,7 +338,7 @@ class RepositorySimulator:
         delegator.delegations.roles[role.name] = role
 
         # By default add one new key for the role
-        signer = CryptoSigner.generate_ecdsa()
+        signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
         delegator.add_key(signer.public_key, role.name)
         self.add_signer(role.name, signer)
 
@@ -364,7 +364,7 @@ class RepositorySimulator:
         ):
             raise ValueError("Can't add a succinct_roles when delegated roles are used")
 
-        signer = CryptoSigner.generate_ecdsa()
+        signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
         succinct_roles = SuccinctRoles([], 1, bit_length, name_prefix)
         delegator.delegations = Delegations({}, None, succinct_roles)
 
@@ -404,7 +404,7 @@ class RepositorySimulator:
 
     def add_key(self, role: str, delegator_name: str = Root.type) -> None:
         """add new public key to delegating metadata and store the signer for role"""
-        signer = CryptoSigner.generate_ecdsa()
+        signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
 
         # Add key to delegating metadata
         delegator = self.mds[delegator_name].signed

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -15,7 +15,7 @@ def test_basic_init_and_refresh(client: ClientRunner, server: SimulatorServer) -
     Run a refresh, verify client trusted metadata and requests made by the client
     """
     init_data, repo = server.new_test(client.test_name)
-
+    print(init_data.trusted_root)
     # Run the test: step 1:  initialize client
     assert client.init_client(init_data) == 0
 
@@ -166,29 +166,29 @@ def test_timestamp_content_changes(
     assert client.version(Timestamp.type) == initial_timestamp_meta_ver
 
 
-def test_new_targets_hash_mismatch(
+def test_basic_metadata_hash_support(
     client: ClientRunner, server: SimulatorServer
 ) -> None:
-    # Check against snapshot role's targets hashes
+    """Verify that clients supports hashes for metadata"""
     init_data, repo = server.new_test(client.test_name)
 
-    assert client.init_client(init_data) == 0
-    client.refresh(init_data)
-
+    # Construct repository with hashes in timestamp/snapshot
     repo.compute_metafile_hashes_length = True
-    repo.update_snapshot()
+    repo.update_snapshot()  # v2
 
-    client.refresh(init_data)
+    assert client.init_client(init_data) == 0
+    # Verify client accepts correct hashes
+    assert client.refresh(init_data) == 0
 
-    # Modify targets contents without updating
-    # snapshot's targets hashes
-    repo.targets.version += 1
+    # Modify targets metadata, leave hashes in snapshot to wrong values
+    repo.targets.version += 1  # v2
     repo.snapshot.meta["targets.json"].version = repo.targets.version
-    repo.snapshot.version += 1
+    repo.snapshot.version += 1  # v3
     repo.update_timestamp()
 
-    client.refresh(init_data)
-    assert client.version(Snapshot.type) == 1
+    # Verify client refuses targets that does not match hashes
+    assert client.refresh(init_data) == 1
+    assert client.version(Snapshot.type) == 3
     assert client.version(Targets.type) == 1
 
 

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -15,7 +15,6 @@ def test_basic_init_and_refresh(client: ClientRunner, server: SimulatorServer) -
     Run a refresh, verify client trusted metadata and requests made by the client
     """
     init_data, repo = server.new_test(client.test_name)
-    print(init_data.trusted_root)
     # Run the test: step 1:  initialize client
     assert client.init_client(init_data) == 0
 

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -1,4 +1,3 @@
-from securesystemslib.signer import CryptoSigner
 from tuf.api.metadata import Root, Snapshot
 
 from tuf_conformance.client_runner import ClientRunner
@@ -62,7 +61,7 @@ def test_root_has_keys_but_not_snapshot(
 
     # Add two keyids only to root and expect the client
     # to fail updating
-    signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
+    signer = repo._rsa_signers.pop()
 
     repo.root.roles[Snapshot.type].keyids.append(signer.public_key.keyid)
 
@@ -145,7 +144,7 @@ def test_duplicate_keys_root(client: ClientRunner, server: SimulatorServer) -> N
 
     assert client.init_client(init_data) == 0
 
-    signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
+    signer = repo._rsa_signers.pop()
 
     # Add one key 9 times to root
     for n in range(0, 9):

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -62,7 +62,7 @@ def test_root_has_keys_but_not_snapshot(
 
     # Add two keyids only to root and expect the client
     # to fail updating
-    signer = CryptoSigner.generate_ecdsa()
+    signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
 
     repo.root.roles[Snapshot.type].keyids.append(signer.public_key.keyid)
 
@@ -145,7 +145,7 @@ def test_duplicate_keys_root(client: ClientRunner, server: SimulatorServer) -> N
 
     assert client.init_client(init_data) == 0
 
-    signer = CryptoSigner.generate_ecdsa()
+    signer = CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
 
     # Add one key 9 times to root
     for n in range(0, 9):

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -61,8 +61,7 @@ def test_root_has_keys_but_not_snapshot(
 
     # Add two keyids only to root and expect the client
     # to fail updating
-    signer = repo._rsa_signers.pop()
-
+    signer = repo.new_signer()
     repo.root.roles[Snapshot.type].keyids.append(signer.public_key.keyid)
 
     # Sanity check
@@ -144,7 +143,7 @@ def test_duplicate_keys_root(client: ClientRunner, server: SimulatorServer) -> N
 
     assert client.init_client(init_data) == 0
 
-    signer = repo._rsa_signers.pop()
+    signer = repo.new_signer()
 
     # Add one key 9 times to root
     for n in range(0, 9):


### PR DESCRIPTION
This is to get deterministic signatures: this is a workaround to get the hash tests fixed now (#128). The change of default might be temporary but all other changes are still useful if we switch back to default ecdsa later (like only generating 8 keys instead of 600 keys):
    * Use RSA as the default keytype
    * Create a list of RSA signers at repository_simulator.py import time: Use these in all tests to avoid generating keys in every test
    * Fix the hash test in test_basic.py: it was incorrect.
    * Fix and parametrize the rollback tests (these are the commits from #151)
    
The last bullet point verifies that this works as I wrote the tests in #151 so they fail with main: now they succeed with this keytype change