### PR TITLE
Fix data dir lookup for static tests

### DIFF
--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -90,6 +90,15 @@ class StaticServer(ThreadingHTTPServer):
 
     data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static_data")
 
+    @classmethod
+    def static_test_names(cls) -> list[str]:
+        """Return list of static test names (subdirectories of 'static_data/')."""
+        static_tests = []
+        for static_dir in os.listdir(StaticServer.data_dir):
+            if os.path.isdir(os.path.join(StaticServer.data_dir, static_dir)):
+                static_tests.append(static_dir)
+        return static_tests
+
     def __init__(self) -> None:
         class _StaticReqHandler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:  # noqa: N802

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -88,10 +88,12 @@ class SimulatorServer(ThreadingHTTPServer):
 class StaticServer(ThreadingHTTPServer):
     """Web server to serve static repositories"""
 
+    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static_data")
+
     def __init__(self) -> None:
         class _StaticReqHandler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:  # noqa: N802
-                filepath = os.path.join("tuf_conformance", "static_data", self.path[1:])
+                filepath = os.path.join(StaticServer.data_dir, self.path[1:])
                 try:
                     with open(filepath, "rb") as f:
                         data = f.read()
@@ -108,7 +110,7 @@ class StaticServer(ThreadingHTTPServer):
         self.timeout = 0
 
     def new_test(self, static_dir: str) -> tuple[ClientInitData, str]:
-        sub_dir = os.path.join("tuf_conformance", "static_data", static_dir)
+        sub_dir = os.path.join(self.data_dir, static_dir)
         with open(os.path.join(sub_dir, "initial_root.json"), "rb") as f:
             initial_root = f.read()
 

--- a/tuf_conformance/test_static_repositories.py
+++ b/tuf_conformance/test_static_repositories.py
@@ -1,17 +1,10 @@
-import os
-
 import pytest
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import StaticServer
 
-static_repos = []
-for static_dir in os.listdir(StaticServer.data_dir):
-    if os.path.isdir(os.path.join(StaticServer.data_dir, static_dir)):
-        static_repos.append(static_dir)
 
-
-@pytest.mark.parametrize("static_repo", static_repos)
+@pytest.mark.parametrize("static_repo", StaticServer.static_test_names())
 def test_static_repository(
     static_client: ClientRunner, static_server: StaticServer, static_repo: str
 ) -> None:

--- a/tuf_conformance/test_static_repositories.py
+++ b/tuf_conformance/test_static_repositories.py
@@ -6,8 +6,8 @@ from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import StaticServer
 
 static_repos = []
-for static_dir in os.listdir(os.path.join("tuf_conformance", "static_data")):
-    if os.path.isdir(os.path.join("tuf_conformance", "static_data", static_dir)):
+for static_dir in os.listdir(StaticServer.data_dir):
+    if os.path.isdir(os.path.join(StaticServer.data_dir, static_dir)):
         static_repos.append(static_dir)
 
 


### PR DESCRIPTION
pytest is not executed in the tuf-conformance source dir when the GitHub Action is used.

Build the data dir as relative from simulator_server.py location.

Fixes #156 