### PR TITLE
add assertions to client refreshes

### DIFF
--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -153,14 +153,14 @@ def test_timestamp_content_changes(
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     initial_timestamp_meta_ver = repo.timestamp.snapshot_meta.version
     # Change timestamp without bumping its version in order to test if a new
     # timestamp with the same version will be persisted.
     repo.timestamp.snapshot_meta.version = 100
 
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     assert client.version(Timestamp.type) == initial_timestamp_meta_ver
 
@@ -219,13 +219,13 @@ def test_timestamp_eq_versions_check(
     assert client.init_client(init_data) == 0
 
     # Make a successful update of valid metadata which stores it in cache
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
     initial_timestamp_meta_ver = repo.timestamp.snapshot_meta.version
 
     # Change timestamp without bumping its version in order to test if a new
     # timestamp with the same version will be persisted.
     repo.timestamp.snapshot_meta.version = 100
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     # If the local timestamp md file has the same snapshot_meta.version as
     # the initial one, then the new modified timestamp has not been stored.

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -15,16 +15,16 @@ def test_root_expired(client: ClientRunner, server: SimulatorServer) -> None:
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     repo.bump_root_by_one()  # v2
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     repo.root.expires = utils.get_date_n_days_in_past(1)
     repo.bump_root_by_one()  # v3
     repo.targets.version += 1  # v2
 
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 1
 
     # Clients should check for a freeze attack after persisting (5.3.10),
     # so root should update, but no other MD should update
@@ -65,7 +65,7 @@ def test_targets_expired(client: ClientRunner, server: SimulatorServer) -> None:
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     repo.targets.expires = utils.get_date_n_days_in_past(5)
     repo.update_snapshot()
@@ -100,7 +100,7 @@ def test_expired_metadata(client: ClientRunner, server: SimulatorServer) -> None
     repo.timestamp.expires = now + datetime.timedelta(days=7)
 
     # Refresh
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     repo.targets.version += 1
     repo.timestamp.expires = now + datetime.timedelta(days=21)
@@ -108,7 +108,7 @@ def test_expired_metadata(client: ClientRunner, server: SimulatorServer) -> None
 
     # Mocking time so that local timestamp has expired
     # but the new timestamp has not
-    client.refresh(init_data, days_in_future=18)
+    assert client.refresh(init_data, days_in_future=18) == 0
 
     # Assert that the final version of timestamp/snapshot is version 2
     # which means a successful refresh is performed
@@ -128,7 +128,7 @@ def test_timestamp_expired(client: ClientRunner, server: SimulatorServer) -> Non
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     repo.timestamp.expires = utils.get_date_n_days_in_past(5)
     repo.update_timestamp()  # v2

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -79,7 +79,7 @@ def test_wrong_hashing_algorithm(client: ClientRunner, server: SimulatorServer) 
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     initial_setup_for_key_threshold(client, repo, init_data)
     repo.add_key(Snapshot.type)
@@ -111,7 +111,7 @@ def test_snapshot_threshold(client: ClientRunner, server: SimulatorServer) -> No
     init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
 
     # Add 4 Snapshot keys so that there are 5 in total.
     repo.add_key(Snapshot.type)

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -127,7 +127,7 @@ def test_new_targets_fast_forward_recovery(
     repo.targets.version = 1
     repo.update_snapshot()  # v3
 
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
     assert client.version(Targets.type) == 1
 
 
@@ -151,7 +151,7 @@ def test_new_snapshot_fast_forward_recovery(
     repo.update_timestamp()
 
     # client refreshes the metadata and see the new snapshot version
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
     assert client.version(Snapshot.type) == 99999
 
     repo.rotate_keys(Snapshot.type)
@@ -162,7 +162,7 @@ def test_new_snapshot_fast_forward_recovery(
     repo.snapshot.version = 1
     repo.update_timestamp()
 
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
     assert client.version(Snapshot.type) == 1
 
 
@@ -204,7 +204,7 @@ def test_new_timestamp_fast_forward_recovery(
     repo.timestamp.version = 99999
 
     # client refreshes the metadata and see the new timestamp version
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
     assert client.version(Timestamp.type) == 99999
 
     # repository rotates timestamp keys,
@@ -214,7 +214,7 @@ def test_new_timestamp_fast_forward_recovery(
     repo.timestamp.version = 1
 
     # client refresh the metadata and see the initial timestamp version
-    client.refresh(init_data)
+    assert client.refresh(init_data) == 0
     assert client.version(Timestamp.type) == 1
 
 


### PR DESCRIPTION
With this PR, all client refreshes should have assertions.