### PR TITLE
Test more keytypes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,4 @@ jobs:
         uses: ./
         with:
           entrypoint: "clients/go-tuf/go-tuf"
+          expected-failures: "test_keytype_and_scheme[rsa/rsassa-pss-sha256]"

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ PHONY: test-go-tuf
 test-go-tuf: dev build-go-tuf faketime
 	./env/bin/pytest tuf_conformance \
 		--entrypoint "./clients/go-tuf/go-tuf" \
+		--expected-failures "test_keytype_and_scheme[rsa/rsassa-pss-sha256]" \
 		--repository-dump-dir $(DUMP_DIR)
 	@echo Repository dump in $(DUMP_DIR)
 PHONY: build-go-tuf

--- a/tuf_conformance/conftest.py
+++ b/tuf_conformance/conftest.py
@@ -91,5 +91,6 @@ def conformance_xfail(
     if xfail_option is None:
         return
 
-    if request.node.originalname in xfail_option.split(" "):
+    xfails = xfail_option.split(" ")
+    if request.node.originalname in xfails or request.node.name in xfails:
         request.node.add_marker(pytest.mark.xfail(strict=True))

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -436,9 +436,15 @@ class RepositorySimulator:
             with open(os.path.join(dest_dir, f"{quoted_role}.json"), "wb") as f:
                 f.write(self.fetch_metadata(role))
 
-    def add_key(self, role: str, delegator_name: str = Root.type) -> None:
+    def add_key(
+        self,
+        role: str,
+        delegator_name: str = Root.type,
+        signer: CryptoSigner | None = None,
+    ) -> None:
         """add new public key to delegating metadata and store the signer for role"""
-        signer = self.new_signer()
+        if signer is None:
+            signer = self.new_signer()
 
         # Add key to delegating metadata
         delegator = self.mds[delegator_name].signed

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -63,9 +63,21 @@ SPEC_VER = ".".join(SPECIFICATION_VERSION)
 
 # Generate some signers once (to avoid all tests generating them)
 NUM_SIGNERS = 8
-RSA_PKCS_SIGNERS = [
-    CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256") for _ in range(NUM_SIGNERS)
-]
+SIGNERS = {
+    ("rsa", "rsassa-pss-sha256"): [
+        CryptoSigner.generate_rsa() for _ in range(NUM_SIGNERS)
+    ],
+    ("rsa", "rsa-pkcs1v15-sha256"): [
+        CryptoSigner.generate_rsa(scheme="rsa-pkcs1v15-sha256")
+        for _ in range(NUM_SIGNERS)
+    ],
+    ("ecdsa", "ecdsa-sha2-nistp256"): [
+        CryptoSigner.generate_ecdsa() for _ in range(NUM_SIGNERS)
+    ],
+    ("ed25519", "ed25519"): [
+        CryptoSigner.generate_ed25519() for _ in range(NUM_SIGNERS)
+    ],
+}
 
 
 @dataclass
@@ -110,7 +122,8 @@ class RepositorySimulator:
         now = datetime.datetime.utcnow()
         self.safe_expiry = now.replace(microsecond=0) + datetime.timedelta(days=30)
 
-        self._rsa_pkcs_signers = RSA_PKCS_SIGNERS.copy()
+        # Make a semi-deep copy of generated signers
+        self._generated_signers = {k: v.copy() for k, v in SIGNERS.items()}
 
         # initialize a basic repository structure
         self._initialize()
@@ -153,14 +166,13 @@ class RepositorySimulator:
     ) -> CryptoSigner:
         """Return a Signer (from a set of pre-generated signers)."""
         try:
-            if keytype == "rsa" and scheme == "rsa-pkcs1v15-sha256":
-                return self._rsa_pkcs_signers.pop()
+            return self._generated_signers[(keytype, scheme)].pop()
+        except KeyError:
+            raise ValueError(f"Unsupported keytype/scheme: {keytype}/{scheme}")
         except IndexError:
             raise RuntimeError(
                 f"Test ran out of {keytype}/{scheme} keys (NUM_SIGNERS = {NUM_SIGNERS})"
             )
-
-        raise ValueError("{keytype}/{scheme} not supported yet")
 
     def add_signer(self, role: str, signer: CryptoSigner) -> None:
         if role not in self.signers:


### PR DESCRIPTION
* Setup infrastructure for testing different keytypes: 
   * repository_simulator.py generates NUM_SIGNERS keys for each of those keytypes (most are not currently needed but I thought better be consistent)
   * Currently only a few keytypes are added: Adding more is not hard but a little more work (since securesystemslib CryptoSigner does not even try to offer every possible key -- we can use `cryptography` for that)
 * Test the "standard" TUF keys to start with
 * Fix minor issue in `--expected-failures`
 * Set an expected failure for go-tuf since it does not currently support non-deterministic RSA
 
  