### PR TITLE
Cleanups (and one new test)

### DIFF
--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -129,6 +129,7 @@ def test_expired_local_root(client: ClientRunner, server: SimulatorServer) -> No
     assert client.refresh(init_data, days_in_future=18) == 0
     assert client.version(Root.type) == 3
 
+
 def test_expired_local_timestamp(client: ClientRunner, server: SimulatorServer) -> None:
     """Ensures that the client can update to the latest remote timestamp
     when the local timestamp has expired.

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -98,7 +98,38 @@ def test_targets_expired(client: ClientRunner, server: SimulatorServer) -> None:
     ]
 
 
-def test_expired_timestamp(client: ClientRunner, server: SimulatorServer) -> None:
+def test_expired_local_root(client: ClientRunner, server: SimulatorServer) -> None:
+    """Ensures that client can update to latest root when the local root is expired.
+
+    The updates and verifications are performed with the following timing:
+     - root v2 expiry set to day 7
+     - First updater refresh performed on day 0
+
+     - Repository bumps snapshot and targets to v2 on day 0
+     - Timestamp v2 expiry set to day 21
+     - Second updater refresh performed on day 18,
+       it is successful and timestamp/snaphot final versions are v2"""
+    init_data, repo = server.new_test(client.test_name)
+
+    assert client.init_client(init_data) == 0
+
+    # root v2 expires in 7 days
+    now = datetime.datetime.now(timezone.utc)
+    repo.root.expires = now + datetime.timedelta(days=7)
+    repo.bump_root_by_one()
+
+    # Refresh
+    assert client.refresh(init_data) == 0
+
+    # root v3 expires in 21 days
+    repo.root.expires = now + datetime.timedelta(days=21)
+    repo.bump_root_by_one()
+
+    # Mocking time so that local root (v2) has expired but v3 from repo has not
+    assert client.refresh(init_data, days_in_future=18) == 0
+    assert client.version(Root.type) == 3
+
+def test_expired_local_timestamp(client: ClientRunner, server: SimulatorServer) -> None:
     """Ensures that the client can update to the latest remote timestamp
     when the local timestamp has expired.
 

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -195,13 +195,9 @@ def test_graph_traversal(
     assert client.init_client(init_data) == 0
     init_repo(repo, graphs)
 
-    # Call explicitly refresh to simplify the expected_calls list
-    assert client.refresh(init_data) == 0
-    repo.metadata_statistics.clear()
     assert client.download_target(init_data, "missingpath") == 1
-    # "('root', 2), ('timestamp', None)" gets prepended
-    # in every case, so we compare from the 3rd item in the list.
-    assert repo.metadata_statistics[2:] == exp_calls
+    # skip the top level metadata (root, timestamp, snapshot, targets) in statistics
+    assert repo.metadata_statistics[4:] == exp_calls
 
 
 r"""
@@ -259,9 +255,6 @@ def test_targetfile_search(
     assert client.init_client(init_data) == 0
     init_repo(repo, delegations_tree)
 
-    # Call explicitly refresh to simplify the expected_calls list
-    assert client.refresh(init_data) == 0
-    repo.metadata_statistics.clear()
     if target.found:
         assert client.download_target(init_data, target.targetpath) == 0
         assert client.get_downloaded_target_bytes() == [
@@ -270,7 +263,5 @@ def test_targetfile_search(
     else:
         assert client.download_target(init_data, target.targetpath) == 1
 
-    # repo prepends [('root', 2), ('timestamp', None)]
-    # so we compare equality from the 2nd call to the 3rd-last
-    # call.
-    assert repo.metadata_statistics[2:] == exp_calls
+    # skip the top level metadata (root, timestamp, snapshot, targets) in statistics
+    assert repo.metadata_statistics[4:] == exp_calls


### PR DESCRIPTION
* Remove a few refreshes that were not useful for the tests
* Simplify threshold tests
* try to be descriptive in test names
* Make some metadata_statistics comparisons more elegant
* Add one test for expired local root