### PR TITLE
switch to explicit publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,25 +73,20 @@ make fix
 
 ### Creating (and debugging) tests
 
-Let's say we want to test that clients will not accept a decreasing targets version. We start with a simple skeleton
-test that doesn't assert anything but sets up a repository and runs client refresh against it:
+Let's say we want to test that clients will not accept a decreasing targets version. We start with a simple skeleton test that sets up a repository and runs client refresh against it:
 
 ```python
-def test_targets_version(
+def test_targets_version_rollback(
     client: ClientRunner, server: SimulatorServer
 ) -> None:
-    # Initialize our repository: modify targets version and make sure the version is included in snapshot
+    # Initialize our repository: modify targets version and make sure it's included in snapshot
     init_data, repo = server.new_test(client.test_name)
-    repo.targets.version = 7
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
-    # initialize client-under-test, run refresh
+    # initialize client-under-test
     client.init_client(init_data)
-    client.refresh(init_data)
+    # Run refresh on client-under-test, expect success
+    assert client.refresh(init_data) == 0
 ```
-
-The test initializes the repo and the initial data. It then sets the repo targets version to 7 and publishes the Targets, Snapshot and Timestamp roles. Finally, it initializes the client and refreshes the clients local metadata.
-`repo.publish()` makes the repositorys data public to the client, and it bumps the version of the metadata in the list by one. When a test needs to publish and make the changes available to the client, the `repo.publish()` call must include the role it wants to publish as the first item in the list followed by the roles the client updates before it ordered by last to first. I.e. in order to publish the Targets role, we must also publish Snapshot and Timestamp in that order. `repo.publish()` can also publish the Root role.
 
 We can now run the test:
 
@@ -106,15 +101,33 @@ cat /tmp/test-repos/test_targets_version/refresh-1/targets.json
 cat /tmp/test-repos/test_targets_version/refresh-1/snapshot.json
 ```
 
-The metadata looks as expected (targets version is 8 because we set the version to 7 and then bumped when we invoked `repo.publish()`) so we can add a modification to the end of the test:
+Now, the repository publishes Targets 6 times so that it is version 7. The client then refreshes and the test asserts that the client has Targets version 7. Next, the repository attempts a rollback attack; It attempts to make the client download metadata for the Targets role that is a lower version than the version the client already has. To do that, the test deletes the already published Targets and republishes 5 times. Now, the repositorys Targets version is 5. The test publishes Snapshot and Timestamp too so the client can see the latest Targets changes. The client now refreshes which must fail to make the client spec-compliant. Finally, the test asserts that the client still has version 7. 
 
 ```python
-    # Make an non-compliant change in repository
-    repo.targets.version = 6
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+  # Bump version of Targest 6 times.
+    for i in range(6):
+        repo.publish([Targets.type])
+    repo.publish([Snapshot.type, Timestamp.type])
+    
+    # Client refreshes and downloads Targets version 7
+    assert client.refresh(init_data) == 0
+    assert client.version(Targets.type) == 7
 
-    # refresh client again
-    client.refresh(init_data)
+    # The repository deletes all published Targets
+    # and republishes to version 5.
+    # This is a rollback attack.
+    del repo.signed_mds[Targets.type]
+    for i in range(5):
+        repo.publish([Targets.type], verify_version=False)
+    repo.publish([Snapshot.type, Timestamp.type])
+
+    # Now the client should fail because it has version 7
+    # locally and the repository is presenting it with
+    # version 5
+    assert client.refresh(init_data) == 1
+
+    # Make sure the client still has version 7
+    assert client.version(Targets.type) == 7
 ```
 
 Running the test again results in a second repository version being dumped (each client refresh leads to a dump): 
@@ -133,28 +146,41 @@ The repository metadata looks as expected (but not spec-compliant) so we can add
 The final test looks like this:
 
 ```python
-def test_targets_version(
+def test_targets_version_rollback(
     client: ClientRunner, server: SimulatorServer
 ) -> None:
     # Initialize our repository: modify targets version and make sure it's included in snapshot
     init_data, repo = server.new_test(client.test_name)
-    repo.targets.version = 7
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # initialize client-under-test
     client.init_client(init_data)
-
     # Run refresh on client-under-test, expect success
     assert client.refresh(init_data) == 0
 
-    # Make a non-compliant change in repository
-    repo.targets.version = 6
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    # Bump version of Targest 6 times.
+    for i in range(6):
+        repo.publish([Targets.type])
+    repo.publish([Snapshot.type, Timestamp.type])
+    
+    # Client refreshes and downloads Targets version 7
+    assert client.refresh(init_data) == 0
+    assert client.version(Targets.type) == 7
 
-    # refresh client again, expect failure and refusal to accept snapshot and targets
+    # The repository deletes all published Targets
+    # and republishes to version 5.
+    # This is a rollback attack.
+    del repo.signed_mds[Targets.type]
+    for i in range(5):
+        repo.publish([Targets.type], verify_version=False)
+    repo.publish([Snapshot.type, Timestamp.type])
+
+    # Now the client should fail because it has version 7
+    # locally and the repository is presenting it with
+    # version 5
     assert client.refresh(init_data) == 1
-    assert client.version(Snapshot.type) == 3
-    assert client.version(Targets.type) == 8
+
+    # Make sure the client still has version 7
+    assert client.version(Targets.type) == 7
 ```
 
 ### Releasing

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -32,7 +32,7 @@ Example::
 import datetime
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from urllib import parse
 
@@ -59,8 +59,6 @@ from tuf_conformance.metadata import MetadataTest, RootTest
 logger = logging.getLogger(__name__)
 
 SPEC_VER = ".".join(SPECIFICATION_VERSION)
-
-ALL_TOPLEVEL_TYPES = [Root.type, Timestamp.type, Snapshot.type, Targets.type]
 
 # Generate some signers once (to avoid all tests generating them)
 NUM_SIGNERS = 9
@@ -212,9 +210,7 @@ class RepositorySimulator:
             [Targets.type, Snapshot.type, Timestamp.type, Root.type], bump_version=False
         )
 
-    def publish(
-        self, roles: list[str] = ALL_TOPLEVEL_TYPES, bump_version: bool = True
-    ) -> None:
+    def publish(self, roles: Iterable[str], bump_version: bool = True) -> None:
         for role in roles:
             md = self.mds.get(role)
             if md is None:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -342,7 +342,6 @@ class RepositorySimulator:
                 delegate.version, length, hashes
             )
 
-        self.snapshot.version += 1
         self.publish([Snapshot.type])
         self.update_timestamp()
 

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -194,6 +194,20 @@ class RepositorySimulator:
         self.publish([Targets.type, Snapshot.type, Timestamp.type, Root.type])
 
     def publish(self, roles: Iterable[str], bump_version: bool = True) -> None:
+        """Makes the repositorys metadata public and available to clients.
+
+        Tests run this helper after updating the repositorys metadata
+        and before clients should fetch the repositorys updated metadata.
+
+        publish bumps the version by default. The role must already exist
+        in repo.signed_mds for the repo to be able to bump it.
+
+        When publishing a role that is not root, timestamp or snapshot,
+        publish will create a metafile for the role and add it to snapshot.
+
+        When publishing snapshot, publish will create a metafile for snapshot
+        and add it to timestamp."""
+
         for role in roles:
             md = self.mds.get(role)
             if md is None:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -328,7 +328,6 @@ class RepositorySimulator:
 
         self.timestamp.snapshot_meta = MetaFile(self.snapshot.version, length, hashes)
 
-        self.timestamp.version += 1
         self.publish([Timestamp.type])
 
     def update_snapshot(self) -> None:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -206,8 +206,7 @@ class RepositorySimulator:
             signer = self.new_signer()
             self.root.add_key(signer.public_key, role)
             self.add_signer(role, signer)
-
-        self.publish([Root.type])
+        self.publish([Targets.type, Snapshot.type, Timestamp.type, Root.type])
 
     def publish(
         self, roles: list[str] = ALL_TOPLEVEL_TYPES, bump_version: bool = False

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -300,8 +300,8 @@ class RepositorySimulator:
         # Non-root mds:
         if len(self.signed_mds[role]) == 0:
             raise ValueError(f"The repository has not published metadata for '{role}'")
-        # if version is not None:
-        #    return self.signed_mds[role][version - 1]
+        if version is not None:
+            return self.signed_mds[role][version - 1]
         return self.signed_mds[role][-1]
 
     def _version(self, role: str) -> int:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -48,6 +48,7 @@ from tuf.api.metadata import (
     Root,
     Snapshot,
     SuccinctRoles,
+    T,
     TargetFile,
     Targets,
     Timestamp,
@@ -153,7 +154,7 @@ class RepositorySimulator:
         assert isinstance(signed, Targets)
         return signed
 
-    def all_signed_targets(self) -> Iterator[tuple[str, Targets]]:
+    def all_signed_targets(self) -> Iterator[tuple[str, Metadata[T]]]:
         """Yield role name and signed portion of targets one by one."""
         for role, mds in self.signed_mds.items():
             for md in mds:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -157,9 +157,10 @@ class RepositorySimulator:
 
     def all_targets(self) -> Iterator[tuple[str, Targets]]:
         """Yield role name and signed portion of targets one by one."""
-        for role, md in self.mds.items():
-            if role not in [Root.type, Timestamp.type, Snapshot.type]:
-                yield role, md.signed
+        for role, mds in self.signed_mds.items():
+            for md in mds:
+                if role not in [Root.type, Timestamp.type, Snapshot.type]:
+                    yield role, Metadata.from_bytes(md).signed
 
     def new_signer(
         self, keytype: str = "rsa", scheme: str = "rsa-pkcs1v15-sha256"
@@ -337,7 +338,6 @@ class RepositorySimulator:
     def update_snapshot(self) -> None:
         """Update snapshot, assign targets versions and update timestamp."""
         for role, delegate in self.all_targets():
-            self.publish([role])
             hashes = None
             length = None
             if self.compute_metafile_hashes_length:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -437,22 +437,14 @@ class RepositorySimulator:
 
         for ver in range(1, len(self.signed_mds[Root.type]) + 1):
             with open(os.path.join(dest_dir, f"{ver}.root.json"), "wb") as f:
-                try:
-                    data = self.fetch_metadata(Root.type, ver)
-                except ValueError:
-                    data = b"No metadata found"
-                f.write(data)
+                f.write(self.fetch_metadata(Root.type, ver))
 
-        for role in self.mds:
+        for role in self.signed_mds:
             if role == Root.type:
                 continue
             quoted_role = parse.quote(role, "")
             with open(os.path.join(dest_dir, f"{quoted_role}.json"), "wb") as f:
-                try:
-                    data = self.fetch_metadata(role)
-                except ValueError:
-                    data = b"No metadata found"
-                f.write(data)
+                f.write(self.fetch_metadata(role))
 
     def add_key(
         self,

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -155,7 +155,7 @@ class RepositorySimulator:
         assert isinstance(signed, Targets)
         return signed
 
-    def all_targets(self) -> Iterator[tuple[str, Targets]]:
+    def all_signed_targets(self) -> Iterator[tuple[str, Targets]]:
         """Yield role name and signed portion of targets one by one."""
         for role, mds in self.signed_mds.items():
             for md in mds:
@@ -334,7 +334,7 @@ class RepositorySimulator:
 
     def update_snapshot(self) -> None:
         """Update snapshot, assign targets versions and update timestamp."""
-        for role, delegate in self.all_targets():
+        for role, delegate in self.all_signed_targets():
             hashes = None
             length = None
             if self.compute_metafile_hashes_length:

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -329,8 +329,7 @@ class RepositorySimulator:
         if self.compute_metafile_hashes_length:
             hashes, length = self._compute_hashes_and_length(Snapshot.type)
 
-        md = self.mds[Timestamp.type]
-        md.signed.snapshot_meta = MetaFile(self.snapshot.version, length, hashes)
+        self.timestamp.snapshot_meta = MetaFile(self.snapshot.version, length, hashes)
 
         self.timestamp.version += 1
         self.publish([Timestamp.type])

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -301,7 +301,19 @@ class RepositorySimulator:
     def fetch_metadata(self, role: str, version: int | None = None) -> bytes:
         """Return signed metadata for 'role', using 'version' if it is given.
 
-        If version is None, non-versioned metadata is being requested.
+        If version is None, non-versioned metadata is being requested, and the
+        repository will return the metadata it has published last.
+
+        fetch_metadata versions its metadata by storing the version in
+        repo.signed_mds[role][version-1].
+
+        For the metadata to be available to the client, it must exist in
+        repo.signed_mds. repo.publish() is responsible for makeing the
+        metadata available in repo.signed_mds. The common workflow for
+        making changes in a test and fetching is:
+        1. Make changes to the metadata in the test
+        2. Publish the metadata by way of repo.publish([role])
+        3. The client can now fetch the updated metadata.
         """
 
         # decode role for the metadata

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -196,19 +196,12 @@ class RepositorySimulator:
         self.mds[Timestamp.type] = MetadataTest(Timestamp(expires=self.safe_expiry))
         self.mds[Root.type] = MetadataTest(RootTest(expires=self.safe_expiry))
 
-        self.signed_mds[Targets.type] = []
-        self.signed_mds[Snapshot.type] = []
-        self.signed_mds[Timestamp.type] = []
-        self.signed_mds[Root.type] = []
-
         for role in TOP_LEVEL_ROLE_NAMES:
             signer = self.new_signer()
             self.root.add_key(signer.public_key, role)
             self.add_signer(role, signer)
 
-        self.publish(
-            [Targets.type, Snapshot.type, Timestamp.type, Root.type], bump_version=False
-        )
+        self.publish([Targets.type, Snapshot.type, Timestamp.type, Root.type])
 
     def publish(self, roles: Iterable[str], bump_version: bool = True) -> None:
         for role in roles:
@@ -216,7 +209,8 @@ class RepositorySimulator:
             if md is None:
                 raise ValueError(f"Unknown role {role}")
 
-            if bump_version:
+            # only bump if there is a version already (this avoids bumping initial v1)
+            if bump_version and role in self.signed_mds:
                 md.signed.version += 1
 
             md.signatures.clear()

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -207,7 +207,10 @@ class RepositorySimulator:
             signer = self.new_signer()
             self.root.add_key(signer.public_key, role)
             self.add_signer(role, signer)
-        self.publish([Targets.type, Snapshot.type, Timestamp.type, Root.type])
+
+        self.publish(
+            [Targets.type, Snapshot.type, Timestamp.type, Root.type], bump_version=False
+        )
 
     def publish(
         self, roles: list[str] = ALL_TOPLEVEL_TYPES, bump_version: bool = True

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -210,7 +210,7 @@ class RepositorySimulator:
         self.publish([Targets.type, Snapshot.type, Timestamp.type, Root.type])
 
     def publish(
-        self, roles: list[str] = ALL_TOPLEVEL_TYPES, bump_version: bool = False
+        self, roles: list[str] = ALL_TOPLEVEL_TYPES, bump_version: bool = True
     ) -> None:
         for role in roles:
             md = self.mds.get(role)

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -312,9 +312,6 @@ class RepositorySimulator:
 
     def _compute_hashes_and_length(self, role: str) -> tuple[dict[str, str], int]:
         md = Metadata.from_bytes(self.signed_mds[role][-1])
-        md.signatures.clear()
-        for signer in self.signers[role].values():
-            md.sign(signer, append=True)
         data = md.to_bytes(JSONSerializer())
         digest_object = sslib_hash.digest(sslib_hash.DEFAULT_HASH_ALGORITHM)
         digest_object.update(data)

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -311,11 +311,8 @@ class RepositorySimulator:
         If version is None, non-versioned metadata is being requested, and the
         repository will return the metadata it has published last.
 
-        fetch_metadata versions its metadata by storing the version in
-        repo.signed_mds[role][version-1].
-
         For the metadata to be available to the client, it must exist in
-        repo.signed_mds. repo.publish() is responsible for makeing the
+        repo.signed_mds. repo.publish() is responsible for making the
         metadata available in repo.signed_mds. The common workflow for
         making changes in a test and fetching is:
         1. Make changes to the metadata in the test
@@ -326,14 +323,11 @@ class RepositorySimulator:
         # decode role for the metadata
         role = parse.unquote(role, encoding="utf-8")
 
-        if role == Root.type:
-            if version is None or version > len(self.signed_mds[Root.type]):
-                raise ValueError(f"Unknown root version {version}")
-            return self.signed_mds[Root.type][version - 1]
-        # Non-root mds:
         if len(self.signed_mds[role]) == 0:
             raise ValueError(f"The repository has not published metadata for '{role}'")
         if version is not None:
+            if version < 1 or version > len(self.signed_mds[role]):
+                raise ValueError(f"Unknown {role} version {version}")
             return self.signed_mds[role][version - 1]
         return self.signed_mds[role][-1]
 

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -311,8 +311,7 @@ class RepositorySimulator:
         return signed.version
 
     def _compute_hashes_and_length(self, role: str) -> tuple[dict[str, str], int]:
-        md = Metadata.from_bytes(self.signed_mds[role][-1])
-        data = md.to_bytes(JSONSerializer())
+        data = self.signed_mds[role][-1]
         digest_object = sslib_hash.digest(sslib_hash.DEFAULT_HASH_ALGORITHM)
         digest_object.update(data)
         hashes = {sslib_hash.DEFAULT_HASH_ALGORITHM: digest_object.hexdigest()}

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -212,8 +212,7 @@ class RepositorySimulator:
     def publish(
         self, roles: list[str] = ALL_TOPLEVEL_TYPES, bump_version: bool = False
     ) -> None:
-        for r in roles:
-            role = parse.unquote(r, encoding="utf-8")
+        for role in roles:
             md = self.mds.get(role)
             if md is None:
                 raise ValueError(f"Unknown role {role}")

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -100,7 +100,7 @@ class RepositorySimulator:
         # All signed metadata
         self.signed_mds: dict[str, list[bytes]] = {}
 
-        # signers are used on-demand at fetch time to sign metadata
+        # signers are used to sign metadata
         # keys are roles, values are dicts of {keyid: signer}
         self.signers: dict[str, dict[str, Signer]] = {}
 

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -301,7 +301,7 @@ class RepositorySimulator:
         # Non-root mds:
         if len(self.signed_mds[role]) == 0:
             raise ValueError(f"The repository has not published metadata for '{role}'")
-        #if version is not None:
+        # if version is not None:
         #    return self.signed_mds[role][version - 1]
         return self.signed_mds[role][-1]
 

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -193,7 +193,7 @@ class RepositorySimulator:
 
         self.publish([Targets.type, Snapshot.type, Timestamp.type, Root.type])
 
-    def publish(self, roles: Iterable[str], bump_version: bool = True) -> None:
+    def publish(self, roles: Iterable[str], verify_version: bool = True) -> None:
         """Makes the repositorys metadata public and available to clients.
 
         Tests run this helper after updating the repositorys metadata
@@ -214,7 +214,7 @@ class RepositorySimulator:
                 raise ValueError(f"Unknown role {role}")
 
             # only bump if there is a version already (this avoids bumping initial v1)
-            if bump_version and role in self.signed_mds:
+            if role in self.signed_mds:
                 md.signed.version += 1
 
             md.signatures.clear()
@@ -230,6 +230,13 @@ class RepositorySimulator:
 
             if role not in self.signed_mds:
                 self.signed_mds[role] = []
+            expected_ver = len(self.signed_mds[role]) + 1
+            if verify_version and md.signed.version != expected_ver:
+                raise ValueError(
+                    f"RepositorySimulator Expected {role} v{expected_ver}, got "
+                    "v{md.signed.version}. Use verify_version=False if this is intended"
+                )
+
             self.signed_mds[role].append(md.to_bytes(JSONSerializer()))
 
             hashes = None

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -34,7 +34,7 @@ class _ReqHandler(BaseHTTPRequestHandler):
 
         try:
             data = repo.fetch(path)
-        except ValueError as e:
+        except (ValueError, IndexError) as e:
             self.send_error(404, str(e))
             return
         self.send_response(200)

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -4,8 +4,6 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from os import path
 from urllib import parse
 
-from tuf.api.metadata import Snapshot, Targets, Timestamp
-
 from tuf_conformance.repository_simulator import RepositorySimulator
 
 

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -64,7 +64,7 @@ class SimulatorServer(ThreadingHTTPServer):
         self.repos: dict[str, RepositorySimulator] = {}
 
     def new_test(
-        self, name: str, publish_all: bool = True
+        self, name: str
     ) -> tuple[ClientInitData, RepositorySimulator]:
         """Return a tuple of
         * A new repository simulator (for test case to control)
@@ -84,10 +84,8 @@ class SimulatorServer(ThreadingHTTPServer):
         )
 
         # The repository simulator publishes the root.
-        # If the test needs to publish all metadata, we publish the
-        # remaining here:
-        if publish_all:
-            repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+        # Here, we publish the remaining metadata:
+        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
         return client_data, repo
 

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -63,9 +63,7 @@ class SimulatorServer(ThreadingHTTPServer):
         # key is test name, value is the repository sim for that test
         self.repos: dict[str, RepositorySimulator] = {}
 
-    def new_test(
-        self, name: str
-    ) -> tuple[ClientInitData, RepositorySimulator]:
+    def new_test(self, name: str) -> tuple[ClientInitData, RepositorySimulator]:
         """Return a tuple of
         * A new repository simulator (for test case to control)
         * client initialization parameters (so client can find the simulated repo)

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -81,10 +81,6 @@ class SimulatorServer(ThreadingHTTPServer):
             repo.fetch_metadata("root", 1),
         )
 
-        # The repository simulator publishes the root.
-        # Here, we publish the remaining metadata:
-        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-
         return client_data, repo
 
     def debug_dump(self, test_name: str) -> None:

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -127,7 +127,7 @@ def test_unsigned_metadata(
     Expect the refresh to succeed until that point, but not continue from that point.
     """
 
-    init_data, repo = server.new_test(client.test_name, publish_all=False)
+    init_data, repo = server.new_test(client.test_name)
 
     # remove signing key for role, increase version
     repo.signers[role].popitem()

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -178,8 +178,7 @@ def test_basic_metadata_hash_support(
 
     # Construct repository with hashes in timestamp/snapshot
     repo.compute_metafile_hashes_length = True
-    repo.publish([Targets.type])  # v2
-    repo.publish([Snapshot.type, Timestamp.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])  # v2, v2, v2
 
     assert client.init_client(init_data) == 0
     # Verify client accepts correct hashes

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -135,7 +135,7 @@ def test_unsigned_metadata(
     if role == "root":
         repo.publish([Root.type])
     else:
-        repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.init_client(init_data) == 0
 

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -159,7 +159,7 @@ def test_timestamp_content_changes(
     assert client.init_client(init_data) == 0
     assert client.refresh(init_data) == 0
 
-    # Change timestamp v1: client should not download a new one if it has v1 already
+    # Change timestamp v1: client should not use the new one if it already has a v1
     repo.timestamp.snapshot_meta.version = 100
     del repo.signed_mds[Timestamp.type]
     repo.publish([Timestamp.type])  # v1

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -175,7 +175,7 @@ def test_basic_metadata_hash_support(
     # Construct repository with hashes in timestamp/snapshot
     repo.compute_metafile_hashes_length = True
     repo.update_snapshot()  # v2
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    #repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.init_client(init_data) == 0
     # Verify client accepts correct hashes

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -178,25 +178,25 @@ def test_basic_metadata_hash_support(
 
     # Construct repository with hashes in timestamp/snapshot
     repo.compute_metafile_hashes_length = True
-    repo.update_snapshot()  # v2
-    # repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    repo.publish([Targets.type])  # v2
+    repo.publish([Snapshot.type, Timestamp.type])
 
     assert client.init_client(init_data) == 0
     # Verify client accepts correct hashes
     assert client.refresh(init_data) == 0
 
-    # Modify targets metadata, leave hashes in snapshot to wrong values
-    repo.targets.version += 1  # v2
-    repo.snapshot.meta["targets.json"].version = repo.targets.version
-    repo.snapshot.version += 1  # v3
-    repo.publish([Snapshot.type])
-    repo.update_timestamp()
-    repo.publish([Timestamp.type])
+    # Modify targets metadata, set hash in snapshot to wrong value
+    repo.publish([Targets.type])  # v3
+    assert repo.snapshot.meta["targets.json"].hashes
+    repo.snapshot.meta["targets.json"].hashes["sha256"] = (
+        "46419349341cfb2d95f6ae3d4cd5c3d3dd7f4673985dad42a45130be5e0531a0"
+    )
+    repo.publish([Snapshot.type, Timestamp.type])
 
-    # Verify client refuses targets that does not match hashes
+    # Verify client refuses targets v3 that does not match hashes
     assert client.refresh(init_data) == 1
-    assert client.version(Snapshot.type) == 2
-    assert client.version(Targets.type) == 1
+    assert client.version(Snapshot.type) == 3
+    assert client.version(Targets.type) == 2
 
 
 def test_new_targets_version_mismatch(

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -258,7 +258,7 @@ def test_custom_fields(client: ClientRunner, server: SimulatorServer) -> None:
     keyid = repo.root.roles[Root.type].keyids[0]
     repo.root.keys[keyid].unrecognized_fields["extra-field"] = {"a": 1, "b": 2}
     repo.root.roles[Root.type].unrecognized_fields["another-field"] = "value"
-    repo.publish([Root.type], bump_version=True)
+    repo.publish([Root.type])
 
     # client should accept new root: The signed content contains the unknown fields
     assert client.refresh(init_data) == 0

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -195,7 +195,7 @@ def test_basic_metadata_hash_support(
 
     # Verify client refuses targets that does not match hashes
     assert client.refresh(init_data) == 1
-    assert client.version(Snapshot.type) == 3
+    assert client.version(Snapshot.type) == 2
     assert client.version(Targets.type) == 1
 
 

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -135,7 +135,6 @@ def test_unsigned_metadata(
 
     # remove signing key for role, increase version
     repo.signers[role].popitem()
-    repo.mds[role].signed.version += 1
     if role == "root":
         repo.publish([Root.type])
     else:

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -202,25 +202,6 @@ def test_basic_metadata_hash_support(
     assert client.version(Targets.type) == 2
 
 
-def test_new_targets_version_mismatch(
-    client: ClientRunner, server: SimulatorServer
-) -> None:
-    """Create new targets version. Check that client does not
-    download it as the version is not in snapshot.meta
-    """
-    init_data, repo = server.new_test(client.test_name)
-
-    assert client.init_client(init_data) == 0
-    assert client.refresh(init_data) == 0
-
-    repo.publish([Targets.type])
-
-    assert client.refresh(init_data) == 0
-    # Check that the client still has the correct targets version
-    assert client.version(Targets.type) == 1
-    assert repo.metadata_statistics[-1] == (Timestamp.type, None)
-
-
 def test_custom_fields(client: ClientRunner, server: SimulatorServer) -> None:
     """Verify that client copes with unexpected fields in metadata.
 

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -175,7 +175,7 @@ def test_basic_metadata_hash_support(
     # Construct repository with hashes in timestamp/snapshot
     repo.compute_metafile_hashes_length = True
     repo.update_snapshot()  # v2
-    #repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    # repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.init_client(init_data) == 0
     # Verify client accepts correct hashes

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -128,6 +128,10 @@ def test_unsigned_metadata(
     """
 
     init_data, repo = server.new_test(client.test_name)
+    # Removed published roles:
+    del repo.signed_mds[Targets.type]
+    del repo.signed_mds[Snapshot.type]
+    del repo.signed_mds[Timestamp.type]
 
     # remove signing key for role, increase version
     repo.signers[role].popitem()

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -74,7 +74,7 @@ def test_snapshot_expired(client: ClientRunner, server: SimulatorServer) -> None
         (Root.type, 1),
         (Snapshot.type, 1),
         (Targets.type, 1),
-        (Timestamp.type, 2),
+        (Timestamp.type, 3),
     ]
 
 
@@ -97,7 +97,7 @@ def test_targets_expired(client: ClientRunner, server: SimulatorServer) -> None:
         (Root.type, 1),
         (Snapshot.type, 2),
         (Targets.type, 1),
-        (Timestamp.type, 2),
+        (Timestamp.type, 3),
     ]
 
 
@@ -157,9 +157,6 @@ def test_expired_local_timestamp(client: ClientRunner, server: SimulatorServer) 
 
     # Bump targets + snapshot version
     # Set next version of repo timestamp to expire in 21 days
-    repo.targets.version += 1
-    repo.snapshot.version += 1
-    repo.timestamp.version += 1
     repo.timestamp.expires = now + datetime.timedelta(days=21)
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.update_snapshot()

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -158,9 +158,11 @@ def test_expired_local_timestamp(client: ClientRunner, server: SimulatorServer) 
     # Bump targets + snapshot version
     # Set next version of repo timestamp to expire in 21 days
     repo.targets.version += 1
+    repo.snapshot.version += 1
+    repo.timestamp.version += 1
     repo.timestamp.expires = now + datetime.timedelta(days=21)
-    repo.update_snapshot()
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    repo.update_snapshot()
 
     # Mocking time so that local timestamp has expired
     # but the new timestamp has not
@@ -171,7 +173,7 @@ def test_expired_local_timestamp(client: ClientRunner, server: SimulatorServer) 
     # with expired local metadata.
     assert client.trusted_roles() == [
         (Root.type, 1),
-        (Snapshot.type, 2),
+        (Snapshot.type, 3),
         (Targets.type, 2),
-        (Timestamp.type, 2),
+        (Timestamp.type, 3),
     ]

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -21,8 +21,7 @@ def test_root_expired(client: ClientRunner, server: SimulatorServer) -> None:
     assert client.refresh(init_data) == 0
 
     repo.root.expires = utils.get_date_n_days_in_past(1)
-    repo.publish([Root.type])  # v3
-    repo.targets.version += 1  # v2
+    repo.publish([Root.type, Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 1
 
@@ -85,9 +84,9 @@ def test_targets_expired(client: ClientRunner, server: SimulatorServer) -> None:
     assert client.refresh(init_data) == 0
 
     repo.targets.expires = utils.get_date_n_days_in_past(5)
-    repo.publish([Snapshot.type, Timestamp.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
-    assert client.refresh(init_data) == 0
+    assert client.refresh(init_data) == 1
 
     # Check that the client still has not accepted expired targets
     assert client.trusted_roles() == [

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -65,8 +65,7 @@ def test_snapshot_expired(client: ClientRunner, server: SimulatorServer) -> None
 
     repo.snapshot.expires = utils.get_date_n_days_in_past(5)
     repo.update_snapshot()
-    repo.publish([Snapshot.type])
-    repo.publish([Timestamp.type])
+    repo.publish([Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 1
 

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -116,14 +116,14 @@ def test_expired_local_root(client: ClientRunner, server: SimulatorServer) -> No
     # root v2 expires in 7 days
     now = datetime.datetime.now(timezone.utc)
     repo.root.expires = now + datetime.timedelta(days=7)
-    repo.publish([Root.type], bump_version=True)
+    repo.publish([Root.type])
 
     # Refresh
     assert client.refresh(init_data) == 0
 
     # root v3 expires in 21 days
     repo.root.expires = now + datetime.timedelta(days=21)
-    repo.publish([Root.type], bump_version=True)
+    repo.publish([Root.type])
 
     # Mocking time so that local root (v2) has expired but v3 from repo has not
     assert client.refresh(init_data, days_in_future=18) == 0

--- a/tuf_conformance/test_expiration.py
+++ b/tuf_conformance/test_expiration.py
@@ -17,11 +17,11 @@ def test_root_expired(client: ClientRunner, server: SimulatorServer) -> None:
     assert client.init_client(init_data) == 0
     assert client.refresh(init_data) == 0
 
-    repo.publish([Root.type], bump_version=True)  # v2
+    repo.publish([Root.type])  # v2
     assert client.refresh(init_data) == 0
 
     repo.root.expires = utils.get_date_n_days_in_past(1)
-    repo.publish([Root.type], bump_version=True)  # v3
+    repo.publish([Root.type])  # v3
     repo.targets.version += 1  # v2
 
     assert client.refresh(init_data) == 1

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -1,5 +1,5 @@
 import pytest
-from tuf.api.metadata import Root, Snapshot, TargetFile, Targets, Timestamp
+from tuf.api.metadata import Snapshot, TargetFile, Targets, Timestamp
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.repository_simulator import Artifact
@@ -22,7 +22,6 @@ def test_client_downloads_expected_file(
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-    repo.update_snapshot()  # v2
 
     # Client updates, sanity check that nothing was downloaded
     assert client.refresh(init_data) == 0
@@ -48,7 +47,6 @@ def test_client_downloads_expected_file_in_sub_dir(
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-    repo.update_snapshot()
 
     assert client.download_target(init_data, target_path) == 0
     assert client.get_downloaded_target_bytes() == [target_content]
@@ -72,7 +70,6 @@ def test_repository_substitutes_target_file(
     repo.add_artifact(Targets.type, target_content_1, target_path_1)
     repo.add_artifact(Targets.type, target_content_2, target_path_2)
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-    repo.update_snapshot()  # v2
 
     # Download one of the artifacts
     assert client.download_target(init_data, target_path_1) == 0
@@ -122,7 +119,6 @@ def test_multiple_changes_to_target(
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-    repo.update_snapshot()  # v2
 
     # Client downloads the file
     assert client.download_target(init_data, target_path) == 0
@@ -147,7 +143,6 @@ def test_multiple_changes_to_target(
 
         # Bump repo snapshot
         repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-        repo.update_snapshot()
 
         # Client only sees every fifth targets version
         if i % 5 == 0:
@@ -172,7 +167,7 @@ def test_multiple_changes_to_target(
 
             # Bump repo snapshot
             repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-            repo.update_snapshot()
+
             # ask client to download (this call may fail or succeed, see
             # test_repository_substitutes_target_file)
             client.download_target(init_data, target_path)
@@ -208,8 +203,6 @@ def test_download_with_hash_algorithms(
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-    repo.update_snapshot()  # v2
-    repo.publish([Root.type], bump_version=True)
 
     assert client.init_client(init_data) == 0
     assert client.download_target(init_data, target_path) == 0
@@ -239,7 +232,6 @@ def test_download_with_unknown_hash_algorithm(
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-    repo.update_snapshot()
 
     assert client.init_client(init_data) == 0
     # Note that we allow the client to actually download the artifact from repo

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -21,7 +21,7 @@ def test_client_downloads_expected_file(
     target_path = "target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # Client updates, sanity check that nothing was downloaded
     assert client.refresh(init_data) == 0
@@ -46,7 +46,7 @@ def test_client_downloads_expected_file_in_sub_dir(
     target_path = "path/to/a/target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.download_target(init_data, target_path) == 0
     assert client.get_downloaded_target_bytes() == [target_content]
@@ -69,7 +69,7 @@ def test_repository_substitutes_target_file(
     target_content_2 = b"content"
     repo.add_artifact(Targets.type, target_content_1, target_path_1)
     repo.add_artifact(Targets.type, target_content_2, target_path_2)
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # Download one of the artifacts
     assert client.download_target(init_data, target_path_1) == 0
@@ -118,7 +118,7 @@ def test_multiple_changes_to_target(
     target_path = "target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # Client downloads the file
     assert client.download_target(init_data, target_path) == 0
@@ -143,7 +143,7 @@ def test_multiple_changes_to_target(
 
         # Bump repo snapshot
         repo.update_snapshot()
-        repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
         # Client only sees every fifth targets version
         if i % 5 == 0:
             # Client downloads the modified artifact
@@ -168,7 +168,7 @@ def test_multiple_changes_to_target(
 
             # Bump repo snapshot
             repo.update_snapshot()
-            repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+            repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
             # ask client to download (this call may fail or succeed, see
             # test_repository_substitutes_target_file)
@@ -204,7 +204,7 @@ def test_download_with_hash_algorithms(
     target = TargetFile.from_data(target_path, target_content, hashes)
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.publish([Root.type], bump_version=True)
 
     assert client.init_client(init_data) == 0
@@ -234,7 +234,7 @@ def test_download_with_unknown_hash_algorithm(
     del target.hashes["sha512"]
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.init_client(init_data) == 0
     # Note that we allow the client to actually download the artifact from repo

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -1,5 +1,5 @@
 import pytest
-from tuf.api.metadata import TargetFile, Targets
+from tuf.api.metadata import Root, Snapshot, TargetFile, Targets, Timestamp
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.repository_simulator import Artifact
@@ -21,6 +21,7 @@ def test_client_downloads_expected_file(
     target_path = "target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
+    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
 
     # Client updates, sanity check that nothing was downloaded
     assert client.refresh(init_data) == 0
@@ -45,6 +46,7 @@ def test_client_downloads_expected_file_in_sub_dir(
     target_path = "path/to/a/target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
+    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
 
     assert client.download_target(init_data, target_path) == 0
     assert client.get_downloaded_target_bytes() == [target_content]
@@ -67,6 +69,7 @@ def test_repository_substitutes_target_file(
     target_content_2 = b"content"
     repo.add_artifact(Targets.type, target_content_1, target_path_1)
     repo.add_artifact(Targets.type, target_content_2, target_path_2)
+    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
 
     # Download one of the artifacts
     assert client.download_target(init_data, target_path_1) == 0
@@ -115,6 +118,7 @@ def test_multiple_changes_to_target(
     target_path = "target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
+    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
 
     # Client downloads the file
     assert client.download_target(init_data, target_path) == 0
@@ -139,7 +143,7 @@ def test_multiple_changes_to_target(
 
         # Bump repo snapshot
         repo.update_snapshot()
-
+        repo.publish([Targets.type, Timestamp.type, Snapshot.type])
         # Client only sees every fifth targets version
         if i % 5 == 0:
             # Client downloads the modified artifact
@@ -164,6 +168,7 @@ def test_multiple_changes_to_target(
 
             # Bump repo snapshot
             repo.update_snapshot()
+            repo.publish([Targets.type, Timestamp.type, Snapshot.type])
 
             # ask client to download (this call may fail or succeed, see
             # test_repository_substitutes_target_file)
@@ -199,6 +204,8 @@ def test_download_with_hash_algorithms(
     target = TargetFile.from_data(target_path, target_content, hashes)
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
+    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Root.type], bump_version=True)
 
     assert client.init_client(init_data) == 0
     assert client.download_target(init_data, target_path) == 0
@@ -227,6 +234,7 @@ def test_download_with_unknown_hash_algorithm(
     del target.hashes["sha512"]
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
+    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
 
     assert client.init_client(init_data) == 0
     # Note that we allow the client to actually download the artifact from repo

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -141,7 +141,7 @@ def test_multiple_changes_to_target(
         new_target_path = f"new-target-{i}"
         repo.add_artifact(Targets.type, new_file_contents, new_target_path)
 
-        # Bump repo snapshot
+        # Bump repo timestamp, snapshot and targets
         repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
         # Client only sees every fifth targets version
@@ -165,7 +165,7 @@ def test_multiple_changes_to_target(
             malicious_file_contents = f"malicious contents {i}".encode()
             repo.artifacts[target_path].data = malicious_file_contents
 
-            # Bump repo snapshot
+            # Bump repo timestamp, snapshot and targets
             repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
             # ask client to download (this call may fail or succeed, see

--- a/tuf_conformance/test_file_download.py
+++ b/tuf_conformance/test_file_download.py
@@ -21,9 +21,6 @@ def test_client_downloads_expected_file(
     target_path = "target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
-    repo.timestamp.version += 1
-    repo.snapshot.version += 1
-    repo.targets.version += 1
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.update_snapshot()  # v2
 
@@ -50,9 +47,6 @@ def test_client_downloads_expected_file_in_sub_dir(
     target_path = "path/to/a/target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
-    repo.timestamp.version += 1
-    repo.snapshot.version += 1
-    repo.targets.version += 1
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.update_snapshot()
 
@@ -77,9 +71,6 @@ def test_repository_substitutes_target_file(
     target_content_2 = b"content"
     repo.add_artifact(Targets.type, target_content_1, target_path_1)
     repo.add_artifact(Targets.type, target_content_2, target_path_2)
-    repo.timestamp.version += 1
-    repo.snapshot.version += 1
-    repo.targets.version += 1
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.update_snapshot()  # v2
 
@@ -130,9 +121,6 @@ def test_multiple_changes_to_target(
     target_path = "target_file.txt"
     target_content = b"target file contents"
     repo.add_artifact(Targets.type, target_content, target_path)
-    repo.timestamp.version += 1
-    repo.snapshot.version += 1
-    repo.targets.version += 1
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.update_snapshot()  # v2
 
@@ -158,9 +146,6 @@ def test_multiple_changes_to_target(
         repo.add_artifact(Targets.type, new_file_contents, new_target_path)
 
         # Bump repo snapshot
-        repo.timestamp.version += 1
-        repo.snapshot.version += 1
-        repo.targets.version += 1
         repo.publish([Targets.type, Snapshot.type, Timestamp.type])
         repo.update_snapshot()
 
@@ -186,9 +171,6 @@ def test_multiple_changes_to_target(
             repo.artifacts[target_path].data = malicious_file_contents
 
             # Bump repo snapshot
-            repo.timestamp.version += 1
-            repo.snapshot.version += 1
-            repo.targets.version += 1
             repo.publish([Targets.type, Snapshot.type, Timestamp.type])
             repo.update_snapshot()
             # ask client to download (this call may fail or succeed, see
@@ -225,9 +207,6 @@ def test_download_with_hash_algorithms(
     target = TargetFile.from_data(target_path, target_content, hashes)
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
-    repo.timestamp.version += 1
-    repo.snapshot.version += 1
-    repo.targets.version += 1
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.update_snapshot()  # v2
     repo.publish([Root.type], bump_version=True)
@@ -259,9 +238,6 @@ def test_download_with_unknown_hash_algorithm(
     del target.hashes["sha512"]
     repo.targets.targets[target_path] = target
     repo.artifacts[target_path] = Artifact(target_content, target)
-    repo.timestamp.version += 1
-    repo.snapshot.version += 1
-    repo.targets.version += 1
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.update_snapshot()
 

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -156,14 +156,14 @@ def test_keytype_and_scheme(
     signer = repo.new_signer(keytype, scheme)
     repo.add_key(Root.type, signer=signer)
     repo.root.roles[Root.type].threshold += 1
-    repo.publish([Root.type], bump_version=True)
+    repo.publish([Root.type])
 
     assert client.refresh(init_data) == 0
     assert client.version(Root.type) == 2
 
     # Create new root version. Replace the correct signature with one that looks
     # reasonable for the keytype but is incorrect. Expect client to refuse the new root.
-    repo.publish([Root.type], bump_version=True)
+    repo.publish([Root.type])
     root_md = Metadata.from_bytes(repo.signed_mds[Root.type].pop())
     root_md.signatures[signer.public_key.keyid].signature = bad_sig
     repo.signed_mds[Root.type].append(root_md.to_bytes())

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -51,7 +51,7 @@ def test_deprecated_keyid_hash_algorithms(
     # Set snapshot keys "keyid_hash_algorithms" to an incorrect algorithm.
     valid_key = repo.root.roles[Snapshot.type].keyids[0]
     repo.root.keys[valid_key].unrecognized_fields = {"keyid_hash_algorithms": "md5"}
-    repo.publish([Root.type], bump_version=True)  # v2
+    repo.publish([Root.type])  # v2
 
     # All metadata should update; even though "keyid_hash_algorithms"
     # is wrong, it is not a part of the TUF spec.

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -27,7 +27,7 @@ def test_snapshot_does_not_meet_threshold(
         repo.add_key(Snapshot.type)
     repo.publish([Root.type], bump_version=True)  # v2
     repo.update_snapshot()  # v2
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.init_client(init_data) == 0
     assert client.refresh(init_data) == 0
@@ -35,7 +35,7 @@ def test_snapshot_does_not_meet_threshold(
     # Remove a signer from snapshot: amount of signatures will be 2, below threshold
     repo.signers[Snapshot.type].popitem()
     repo.update_snapshot()  # v3
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # snapshot v3 does not meet the threshold anymore:
     assert client.refresh(init_data) == 1
@@ -83,7 +83,7 @@ def test_snapshot_has_too_few_keys(
 
     repo.publish([Root.type], bump_version=True)  # v2
     repo.update_snapshot()  # v2
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # Ensure that client does not update because it does
     # not have enough keys.

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -115,7 +115,7 @@ def test_duplicate_keys_root(client: ClientRunner, server: SimulatorServer) -> N
     assert client.refresh(init_data) == 1
 
     # client should not have accepted snapshot
-    assert client.version(Snapshot.type) != 1
+    assert client.version(Snapshot.type) is None
 
 
 # keytype, scheme and an example signature from this type of key

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -25,17 +25,14 @@ def test_snapshot_does_not_meet_threshold(
     repo.root.roles[Snapshot.type].threshold = 3
     for _ in range(2):
         repo.add_key(Snapshot.type)
-    repo.publish([Root.type], bump_version=True)  # v2
-    repo.update_snapshot()  # v2
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    repo.publish([Root.type, Targets.type, Snapshot.type, Timestamp.type])  # v2
 
     assert client.init_client(init_data) == 0
     assert client.refresh(init_data) == 0
 
     # Remove a signer from snapshot: amount of signatures will be 2, below threshold
     repo.signers[Snapshot.type].popitem()
-    repo.update_snapshot()  # v3
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])  # v3
 
     # snapshot v3 does not meet the threshold anymore:
     assert client.refresh(init_data) == 1
@@ -80,10 +77,7 @@ def test_snapshot_has_too_few_keys(
     # Set higher threshold than we have keys such that the
     # client should not successfully update.
     repo.root.roles[Snapshot.type].threshold = 6
-
-    repo.publish([Root.type], bump_version=True)  # v2
-    repo.update_snapshot()  # v2
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    repo.publish([Root.type, Snapshot.type, Timestamp.type])
 
     # Ensure that client does not update because it does
     # not have enough keys.
@@ -110,12 +104,10 @@ def test_duplicate_keys_root(client: ClientRunner, server: SimulatorServer) -> N
 
     repo.add_signer(Snapshot.type, signer)
 
-    repo.publish([Snapshot.type])
-
     # Set a threshold that will be covered but only by
     # the same key multiple times and not separate keys.
     repo.root.roles[Snapshot.type].threshold = 6
-    repo.publish([Root.type], bump_version=True)
+    repo.publish([Root.type, Snapshot.type, Timestamp.type])
 
     # This should fail for one of two reasons:
     # 1. client does not accept root v2 metadata that contains duplicate keyids or

--- a/tuf_conformance/test_quoting_issues.py
+++ b/tuf_conformance/test_quoting_issues.py
@@ -1,7 +1,7 @@
 from urllib import parse
 
 import pytest
-from tuf.api.metadata import DelegatedRole, Targets
+from tuf.api.metadata import DelegatedRole, Snapshot, Targets, Timestamp
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer
@@ -33,8 +33,7 @@ def test_unusual_role_name(
     # Add signer, add the key to roles delegation
     repo.add_key(role, Targets.type)
 
-    repo.publish([role, Targets.type])
-    repo.update_snapshot()
+    repo.publish([role, Targets.type, Snapshot.type, Timestamp.type])
 
     client.init_client(init_data)
     assert client.download_target(init_data, "nonexistent target") == 1

--- a/tuf_conformance/test_quoting_issues.py
+++ b/tuf_conformance/test_quoting_issues.py
@@ -33,9 +33,12 @@ def test_unusual_role_name(
     # Add signer, add the key to roles delegation
     repo.add_key(role, Targets.type)
 
+    #repo.targets.version += 1
+    repo.timestamp.version += 1
+    repo.snapshot.version += 1
     repo.targets.version += 1
-    repo.update_snapshot()
     repo.publish([role, Targets.type, Snapshot.type, Timestamp.type])
+    repo.update_snapshot()
 
     client.init_client(init_data)
     assert client.download_target(init_data, "nonexistent target") == 1

--- a/tuf_conformance/test_quoting_issues.py
+++ b/tuf_conformance/test_quoting_issues.py
@@ -1,7 +1,7 @@
 from urllib import parse
 
 import pytest
-from tuf.api.metadata import DelegatedRole, Snapshot, Targets, Timestamp
+from tuf.api.metadata import DelegatedRole, Targets
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer
@@ -33,11 +33,7 @@ def test_unusual_role_name(
     # Add signer, add the key to roles delegation
     repo.add_key(role, Targets.type)
 
-    #repo.targets.version += 1
-    repo.timestamp.version += 1
-    repo.snapshot.version += 1
-    repo.targets.version += 1
-    repo.publish([role, Targets.type, Snapshot.type, Timestamp.type])
+    repo.publish([role, Targets.type])
     repo.update_snapshot()
 
     client.init_client(init_data)

--- a/tuf_conformance/test_quoting_issues.py
+++ b/tuf_conformance/test_quoting_issues.py
@@ -35,7 +35,7 @@ def test_unusual_role_name(
 
     repo.targets.version += 1
     repo.update_snapshot()
-    repo.publish([role, Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([role, Targets.type, Snapshot.type, Timestamp.type])
 
     client.init_client(init_data)
     assert client.download_target(init_data, "nonexistent target") == 1

--- a/tuf_conformance/test_quoting_issues.py
+++ b/tuf_conformance/test_quoting_issues.py
@@ -1,7 +1,7 @@
 from urllib import parse
 
 import pytest
-from tuf.api.metadata import DelegatedRole, Targets
+from tuf.api.metadata import DelegatedRole, Snapshot, Targets, Timestamp
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer
@@ -35,6 +35,7 @@ def test_unusual_role_name(
 
     repo.targets.version += 1
     repo.update_snapshot()
+    repo.publish([role, Timestamp.type, Snapshot.type, Targets.type])
 
     client.init_client(init_data)
     assert client.download_target(init_data, "nonexistent target") == 1

--- a/tuf_conformance/test_repository_simulator.py
+++ b/tuf_conformance/test_repository_simulator.py
@@ -51,19 +51,19 @@ class TestRepositorySimulator(unittest.TestCase):
         )
 
         self.assertEqual(
-            Metadata.from_bytes(
+            Metadata[Timestamp].from_bytes(
                 repo.signed_mds[Timestamp.type][-1]
             ).signed.snapshot_meta.length,
             expected_length,
         )
         self.assertEqual(
-            Metadata.from_bytes(
+            Metadata[Timestamp].from_bytes(
                 repo.signed_mds[Timestamp.type][-1]
             ).signed.snapshot_meta.hashes,
             expected_hashes,
         )
 
-    def test_timestamp_expired_unittest(self) -> None:
+    def test_update_timestamp(self) -> None:
         tmp_dir = TemporaryDirectory()
         server = SimulatorServer(dump_dir=tmp_dir.name)
         init_data, repo = server.new_test("test_timestamp_expired")

--- a/tuf_conformance/test_repository_simulator.py
+++ b/tuf_conformance/test_repository_simulator.py
@@ -1,0 +1,53 @@
+import unittest
+from tuf_conformance.simulator_server import SimulatorServer
+from tuf.api.metadata import (
+    Metadata,
+    Root,
+    Snapshot,
+    Targets,
+    Timestamp,
+)
+from tuf_conformance import utils
+import datetime
+from datetime import timezone
+
+class TestRepositorySimulator(unittest.TestCase):
+    def test_repo_initialzation(self):
+        server = SimulatorServer(dump_dir="/tmp")
+        init_data, repo = server.new_test("test_repo_initialzation")
+        self.assertEqual(repo.root.version, 1)
+        self.assertEqual(repo.timestamp.version, 1)
+        self.assertEqual(repo.snapshot.version, 1)
+        self.assertEqual(repo.targets.version, 1)
+        self.assertEqual(len(repo.signed_mds), 4)
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Root.type][-1]).signed.version, 1)
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.version, 1)
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Snapshot.type][-1]).signed.version, 1)
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Targets.type][-1]).signed.version, 1)
+
+
+    def test_basic_metadata_hash_support(self):
+        server = SimulatorServer(dump_dir="/tmp")
+        init_data, repo = server.new_test("unittest_basic_metadata_hash_support")
+        repo.compute_metafile_hashes_length = True        
+        repo.update_snapshot()  # v2
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Snapshot.type][-1]).signed.version, 2)
+
+        expected_hashes, expected_length = repo._compute_hashes_and_length(Snapshot.type)
+
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.snapshot_meta.length, expected_length)
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.snapshot_meta.hashes, expected_hashes)
+
+    def test_timestamp_expired(self):
+        server = SimulatorServer(dump_dir="/tmp")
+        init_data, repo = server.new_test("test_timestamp_expired")
+
+        five_days_in_path = utils.get_date_n_days_in_past(5)
+        repo.timestamp.expires = five_days_in_path
+        repo.update_timestamp()  # v2
+        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.expires, five_days_in_path)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tuf_conformance/test_repository_simulator.py
+++ b/tuf_conformance/test_repository_simulator.py
@@ -41,7 +41,7 @@ class TestRepositorySimulator(unittest.TestCase):
         server = SimulatorServer(dump_dir=tmp_dir.name)
         init_data, repo = server.new_test("unittest_basic_metadata_hash_support")
         repo.compute_metafile_hashes_length = True
-        repo.update_snapshot()  # v2
+        repo.publish([Targets.type, Snapshot.type, Timestamp.type])  # v2
         self.assertEqual(
             Metadata.from_bytes(repo.signed_mds[Snapshot.type][-1]).signed.version, 2
         )
@@ -70,7 +70,7 @@ class TestRepositorySimulator(unittest.TestCase):
 
         five_days_in_path = utils.get_date_n_days_in_past(5)
         repo.timestamp.expires = five_days_in_path
-        repo.update_timestamp()  # v2
+        repo.publish([Timestamp.type])
         self.assertEqual(
             Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.expires,
             five_days_in_path,

--- a/tuf_conformance/test_repository_simulator.py
+++ b/tuf_conformance/test_repository_simulator.py
@@ -1,5 +1,6 @@
 import unittest
-from tuf_conformance.simulator_server import SimulatorServer
+from tempfile import TemporaryDirectory
+
 from tuf.api.metadata import (
     Metadata,
     Root,
@@ -7,47 +8,74 @@ from tuf.api.metadata import (
     Targets,
     Timestamp,
 )
+
 from tuf_conformance import utils
-import datetime
-from datetime import timezone
+from tuf_conformance.simulator_server import SimulatorServer
+
 
 class TestRepositorySimulator(unittest.TestCase):
-    def test_repo_initialzation(self):
-        server = SimulatorServer(dump_dir="/tmp")
+    def test_repo_initialzation_unittest(self) -> None:
+        tmp_dir = TemporaryDirectory()
+        server = SimulatorServer(dump_dir=tmp_dir.name)
         init_data, repo = server.new_test("test_repo_initialzation")
         self.assertEqual(repo.root.version, 1)
         self.assertEqual(repo.timestamp.version, 1)
         self.assertEqual(repo.snapshot.version, 1)
         self.assertEqual(repo.targets.version, 1)
         self.assertEqual(len(repo.signed_mds), 4)
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Root.type][-1]).signed.version, 1)
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.version, 1)
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Snapshot.type][-1]).signed.version, 1)
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Targets.type][-1]).signed.version, 1)
+        self.assertEqual(
+            Metadata.from_bytes(repo.signed_mds[Root.type][-1]).signed.version, 1
+        )
+        self.assertEqual(
+            Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.version, 1
+        )
+        self.assertEqual(
+            Metadata.from_bytes(repo.signed_mds[Snapshot.type][-1]).signed.version, 1
+        )
+        self.assertEqual(
+            Metadata.from_bytes(repo.signed_mds[Targets.type][-1]).signed.version, 1
+        )
 
-
-    def test_basic_metadata_hash_support(self):
-        server = SimulatorServer(dump_dir="/tmp")
+    def test_basic_metadata_hash_support_unittest(self) -> None:
+        tmp_dir = TemporaryDirectory()
+        server = SimulatorServer(dump_dir=tmp_dir.name)
         init_data, repo = server.new_test("unittest_basic_metadata_hash_support")
-        repo.compute_metafile_hashes_length = True        
+        repo.compute_metafile_hashes_length = True
         repo.update_snapshot()  # v2
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Snapshot.type][-1]).signed.version, 2)
+        self.assertEqual(
+            Metadata.from_bytes(repo.signed_mds[Snapshot.type][-1]).signed.version, 2
+        )
 
-        expected_hashes, expected_length = repo._compute_hashes_and_length(Snapshot.type)
+        expected_hashes, expected_length = repo._compute_hashes_and_length(
+            Snapshot.type
+        )
 
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.snapshot_meta.length, expected_length)
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.snapshot_meta.hashes, expected_hashes)
+        self.assertEqual(
+            Metadata.from_bytes(
+                repo.signed_mds[Timestamp.type][-1]
+            ).signed.snapshot_meta.length,
+            expected_length,
+        )
+        self.assertEqual(
+            Metadata.from_bytes(
+                repo.signed_mds[Timestamp.type][-1]
+            ).signed.snapshot_meta.hashes,
+            expected_hashes,
+        )
 
-    def test_timestamp_expired(self):
-        server = SimulatorServer(dump_dir="/tmp")
+    def test_timestamp_expired_unittest(self) -> None:
+        tmp_dir = TemporaryDirectory()
+        server = SimulatorServer(dump_dir=tmp_dir.name)
         init_data, repo = server.new_test("test_timestamp_expired")
 
         five_days_in_path = utils.get_date_n_days_in_past(5)
         repo.timestamp.expires = five_days_in_path
         repo.update_timestamp()  # v2
-        self.assertEqual(Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.expires, five_days_in_path)
+        self.assertEqual(
+            Metadata.from_bytes(repo.signed_mds[Timestamp.type][-1]).signed.expires,
+            five_days_in_path,
+        )
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tuf_conformance/test_repository_simulator.py
+++ b/tuf_conformance/test_repository_simulator.py
@@ -51,15 +51,15 @@ class TestRepositorySimulator(unittest.TestCase):
         )
 
         self.assertEqual(
-            Metadata[Timestamp].from_bytes(
-                repo.signed_mds[Timestamp.type][-1]
-            ).signed.snapshot_meta.length,
+            Metadata[Timestamp]
+            .from_bytes(repo.signed_mds[Timestamp.type][-1])
+            .signed.snapshot_meta.length,
             expected_length,
         )
         self.assertEqual(
-            Metadata[Timestamp].from_bytes(
-                repo.signed_mds[Timestamp.type][-1]
-            ).signed.snapshot_meta.hashes,
+            Metadata[Timestamp]
+            .from_bytes(repo.signed_mds[Timestamp.type][-1])
+            .signed.snapshot_meta.hashes,
             expected_hashes,
         )
 

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -122,13 +122,12 @@ def test_new_targets_fast_forward_recovery(
 
     repo.targets.version = 99999
     repo.update_snapshot()  # v2
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 0
     assert client.version(Targets.type) == 99999
 
     repo.rotate_keys(Snapshot.type)
-    repo.publish([Snapshot.type, Timestamp.type])
+        repo.publish([Snapshot.type, Timestamp.type])
     repo.publish([Root.type], bump_version=True)
 
     repo.targets.version = 1

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -182,12 +182,15 @@ def test_new_snapshot_version_mismatch(
     # Increase snapshot version but do not update version in timestamp.snapshot_meta
     repo.publish([Snapshot.type])  # v2
     repo.timestamp.snapshot_meta.version -= 1
-    repo.publish([Timestamp.type])  # v2
+    repo.publish([Root.type, Timestamp.type])  # v2
 
-    # FIXME: the expected results are incorrect -- why would the refresh fail?
-    assert client.refresh(init_data) == 1
-    assert client.trusted_roles() == [(Root.type, 1), (Timestamp.type, 1)]
-    assert repo.metadata_statistics[-1] == (Snapshot.type, 1)
+    assert client.refresh(init_data) == 0
+    assert client.trusted_roles() == [
+        (Root.type, 2),
+        (Snapshot.type, 1),
+        (Targets.type, 1),
+        (Timestamp.type, 2),
+    ]
 
 
 def test_new_timestamp_fast_forward_recovery(

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -215,8 +215,7 @@ def test_new_timestamp_fast_forward_recovery(
     # repository rotates timestamp keys,
     # rolls back timestamp version
     repo.rotate_keys(Timestamp.type)
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-    repo.publish([Root.type])
+    repo.publish([Root.type, Targets.type, Snapshot.type, Timestamp.type])
     repo.timestamp.version = 1
     repo.publish([Timestamp.type], bump_version=False)
 

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -21,7 +21,7 @@ def test_simple_snapshot_rollback(
 
     # Repository performs legitimate update to snapshot
     repo.update_snapshot()  # v2
-    repo.publish([Timestamp.type, Snapshot.type])
+    repo.publish([Snapshot.type, Timestamp.type])
     assert client.refresh(init_data) == 0
 
     # Repository attempts rollback attack (note that the snapshot version in
@@ -122,18 +122,18 @@ def test_new_targets_fast_forward_recovery(
 
     repo.targets.version = 99999
     repo.update_snapshot()  # v2
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 0
     assert client.version(Targets.type) == 99999
 
     repo.rotate_keys(Snapshot.type)
-    repo.publish([Timestamp.type, Snapshot.type])
+    repo.publish([Snapshot.type, Timestamp.type])
     repo.publish([Root.type], bump_version=True)
 
     repo.targets.version = 1
     repo.update_snapshot()  # v3
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 0
     assert client.version(Targets.type) == 1
@@ -157,7 +157,7 @@ def test_new_snapshot_fast_forward_recovery(
     assert client.init_client(init_data) == 0
     repo.snapshot.version = 99999
     repo.update_timestamp()
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # client refreshes the metadata and see the new snapshot version
     assert client.refresh(init_data) == 0
@@ -165,12 +165,12 @@ def test_new_snapshot_fast_forward_recovery(
 
     repo.rotate_keys(Snapshot.type)
     repo.rotate_keys(Timestamp.type)
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.publish([Root.type], bump_version=True)
 
     repo.snapshot.version = 1
     repo.update_timestamp()
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 0
     assert client.version(Snapshot.type) == 1
@@ -222,7 +222,7 @@ def test_new_timestamp_fast_forward_recovery(
     # repository rotates timestamp keys,
     # rolls back timestamp version
     repo.rotate_keys(Timestamp.type)
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     repo.publish([Root.type], bump_version=True)
     repo.timestamp.version = 1
     repo.publish([Timestamp.type])
@@ -254,13 +254,13 @@ def test_targets_rollback(
     # version higher than 1.
     repo.targets.version = 2
     repo.update_snapshot()  # v2
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     assert client.refresh(init_data) == 0
 
     # The new targets must have a lower version than the local trusted one.
     repo.targets.version = 1
     repo.update_snapshot()  # v3
-    repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # Client refresh should fail because of targets rollback
     assert client.refresh(init_data) == 1

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -127,7 +127,7 @@ def test_new_targets_fast_forward_recovery(
     assert client.version(Targets.type) == 99999
 
     repo.rotate_keys(Snapshot.type)
-        repo.publish([Snapshot.type, Timestamp.type])
+    repo.publish([Snapshot.type, Timestamp.type])
     repo.publish([Root.type], bump_version=True)
 
     repo.targets.version = 1

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -184,7 +184,7 @@ def test_new_snapshot_version_mismatch(
     repo.timestamp.snapshot_meta.version -= 1
     repo.publish([Timestamp.type])  # v2
 
-    # FIXEM: the expected results are incorrect -- why would the refresh fail?
+    # FIXME: the expected results are incorrect -- why would the refresh fail?
     assert client.refresh(init_data) == 1
     assert client.trusted_roles() == [(Root.type, 1), (Timestamp.type, 1)]
     assert repo.metadata_statistics[-1] == (Snapshot.type, 1)

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -21,7 +21,6 @@ def test_simple_snapshot_rollback(
 
     # Repository performs legitimate update to snapshot
     repo.update_snapshot()  # v2
-    repo.publish([Snapshot.type, Timestamp.type])
     assert client.refresh(init_data) == 0
 
     # Repository attempts rollback attack (note that the snapshot version in
@@ -50,7 +49,6 @@ def test_new_timestamp_version_rollback(
 
     # Repository performs legitimate update to timestamp
     repo.update_timestamp()  # v2
-    repo.publish([Timestamp.type])
     assert client.refresh(init_data) == 0
 
     # Sanity check that client saw the timestamp update:
@@ -87,14 +85,12 @@ def test_snapshot_rollback(
 
     # Start snapshot version at 2
     repo.update_snapshot()  # v2, timestamp = v2
-    repo.publish([Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 0
 
     # Repo attempts rollback attack
     repo.snapshot.version = 1
     repo.update_timestamp()  # v3
-    repo.publish([Snapshot.type, Timestamp.type])
 
     assert client.refresh(init_data) == 1
 
@@ -253,13 +249,11 @@ def test_targets_rollback(
     # version higher than 1.
     repo.targets.version = 2
     repo.update_snapshot()  # v2
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
     assert client.refresh(init_data) == 0
 
     # The new targets must have a lower version than the local trusted one.
     repo.targets.version = 1
     repo.update_snapshot()  # v3
-    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # Client refresh should fail because of targets rollback
     assert client.refresh(init_data) == 1

--- a/tuf_conformance/test_rollback.py
+++ b/tuf_conformance/test_rollback.py
@@ -152,7 +152,7 @@ def test_new_snapshot_fast_forward_recovery(
     - Bump and publish root
     - Bump the timestamp
     """
-    init_data, repo = server.new_test(client.test_name, publish_all=False)
+    init_data, repo = server.new_test(client.test_name)
 
     assert client.init_client(init_data) == 0
     repo.snapshot.version = 99999

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -167,7 +167,6 @@ def init_repo(repo: RepositorySimulator, test_case: DelegationsTestCase) -> None
             targets = repo.mds[d.rolename].signed
         else:
             targets = Targets(1, None, repo.safe_expiry, {}, None)
-            targets.version = 0  # let publish bump this to 1
 
         # unpack 'd' but skip "delegator"
         role = DelegatedRole(*astuple(d)[1:])

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -181,7 +181,7 @@ def init_repo(repo: RepositorySimulator, test_case: DelegationsTestCase) -> None
         repo.publish([target.rolename])
 
     repo.update_snapshot()
-    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
 
 @pytest.mark.parametrize("graphs", graph_cases, ids=graph_ids)

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -3,7 +3,9 @@ from dataclasses import astuple, dataclass, field
 import pytest
 from tuf.api.metadata import (
     DelegatedRole,
+    Snapshot,
     Targets,
+    Timestamp,
 )
 
 from tuf_conformance.client_runner import ClientRunner
@@ -177,8 +179,7 @@ def init_repo(repo: RepositorySimulator, test_case: DelegationsTestCase) -> None
     for target in test_case.target_files:
         repo.add_artifact(*astuple(target))
 
-    repo.publish(modified_roles)
-    repo.update_snapshot()
+    repo.publish([*modified_roles, Snapshot.type, Timestamp.type])
 
 
 @pytest.mark.parametrize("graphs", graph_cases, ids=graph_ids)

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -173,15 +173,16 @@ def init_repo(repo: RepositorySimulator, test_case: DelegationsTestCase) -> None
         # unpack 'd' but skip "delegator"
         role = DelegatedRole(*astuple(d)[1:])
         repo.add_delegation(d.delegator, role, targets)
-        repo.publish([d.delegator])
         repo.publish([d.rolename])
 
     for target in test_case.target_files:
         repo.add_artifact(*astuple(target))
-        repo.publish([target.rolename])
 
-    repo.update_snapshot()
+    repo.timestamp.version += 1
+    repo.snapshot.version += 1
+    repo.targets.version += 1
     repo.publish([Targets.type, Snapshot.type, Timestamp.type])
+    repo.update_snapshot()
 
 
 @pytest.mark.parametrize("graphs", graph_cases, ids=graph_ids)

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -4,7 +4,9 @@ import pytest
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     DelegatedRole,
+    Snapshot,
     Targets,
+    Timestamp,
 )
 
 from tuf_conformance.client_runner import ClientRunner
@@ -171,11 +173,15 @@ def init_repo(repo: RepositorySimulator, test_case: DelegationsTestCase) -> None
         # unpack 'd' but skip "delegator"
         role = DelegatedRole(*astuple(d)[1:])
         repo.add_delegation(d.delegator, role, targets)
+        repo.publish([d.delegator])
+        repo.publish([d.rolename])
 
     for target in test_case.target_files:
         repo.add_artifact(*astuple(target))
+        repo.publish([target.rolename])
 
     repo.update_snapshot()
+    repo.publish([Targets.type, Timestamp.type, Snapshot.type])
 
 
 @pytest.mark.parametrize("graphs", graph_cases, ids=graph_ids)

--- a/tuf_conformance/test_updater_key_rotations.py
+++ b/tuf_conformance/test_updater_key_rotations.py
@@ -163,7 +163,7 @@ def test_root_rotation(
             repo.root.add_key(signers[i].public_key, Root.type)
         for i in rootver.sigs:
             repo.add_signer(Root.type, signers[i])
-        repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
         repo.publish([Root.type], bump_version=True)
 
     # Make sure our initial root is the v1 we just created
@@ -222,7 +222,7 @@ def test_non_root_rotations(
         for i in md_version.sigs:
             repo.add_signer(role, signers[i])
 
-        repo.publish([Timestamp.type, Snapshot.type, Targets.type])
+        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
         repo.publish([Root.type], bump_version=True)
 
         # run client workflow, assert success/failure

--- a/tuf_conformance/test_updater_key_rotations.py
+++ b/tuf_conformance/test_updater_key_rotations.py
@@ -149,10 +149,8 @@ def test_root_rotation(
 
     # initialize a simulator with repository content we need
     init_data, repo = server.new_test(client.test_name)
-    repo.signed_mds[Root.type].clear()
-    repo.root.version = 0
+    del repo.signed_mds[Root.type]
 
-    repo.signed_mds[Root.type].clear()
     for rootver in root_versions:
         # clear root keys, signers
         repo.root.roles[Root.type].keyids.clear()
@@ -163,8 +161,8 @@ def test_root_rotation(
             repo.root.add_key(signers[i].public_key, Root.type)
         for i in rootver.sigs:
             repo.add_signer(Root.type, signers[i])
-        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-        repo.publish([Root.type], bump_version=True)
+        repo.publish([Root.type])
+    repo.publish([Targets.type, Snapshot.type, Timestamp.type])
 
     # Make sure our initial root is the v1 we just created
     init_data.trusted_root = repo.fetch_metadata("root", 1)
@@ -222,8 +220,7 @@ def test_non_root_rotations(
         for i in md_version.sigs:
             repo.add_signer(role, signers[i])
 
-        repo.publish([Targets.type, Snapshot.type, Timestamp.type])
-        repo.publish([Root.type], bump_version=True)
+        repo.publish([Root.type, Targets.type, Snapshot.type, Timestamp.type])
 
         # run client workflow, assert success/failure
         expected_result = md_version.res


### PR DESCRIPTION
Adds a `signed_mds` value to the `RepositorySimulator` which contains the repositorys released metadata. With this PR, the repository will make changes locally, and the `publish` releases the current state. Prior to this PR, `RepositorySimulator` publishes/signs the metadata when the client requests, but for some tests this has been to much of a constraint. 

`publish` takes a list of the roles it should publish, and it can also bump the roles.