### PR TITLE
Enable all delegation tests for go-tuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .python-version
 build
 clients/go-tuf/go-tuf
+.idea/

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -189,9 +189,6 @@ def test_graph_traversal(
     """Test that delegated roles are traversed in the order of appearance
     in the delegator's metadata, using pre-order depth-first search"""
 
-    if "clients/go-tuf/go-tuf" in client._cmd[0]:
-        pytest.skip("skip for flakiness")
-
     exp_calls = [(role, 1) for role in graphs.visited_order]
 
     init_data, repo = server.new_test(client.test_name)


### PR DESCRIPTION
The following PR enables the delegation tests for the go-tuf client removing the existing skip we had so far

Fixes https://github.com/theupdateframework/tuf-conformance/issues/171