### PR TITLE
Add version mismatch test, refactor README example

### DIFF
--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -233,8 +233,8 @@ class RepositorySimulator:
             expected_ver = len(self.signed_mds[role]) + 1
             if verify_version and md.signed.version != expected_ver:
                 raise ValueError(
-                    f"RepositorySimulator Expected {role} v{expected_ver}, got "
-                    "v{md.signed.version}. Use verify_version=False if this is intended"
+                    f"RepositorySimulator Expected {role} v{expected_ver}, got v"
+                    f"{md.signed.version}. Use verify_version=False if this is intended"
                 )
 
             self.signed_mds[role].append(md.to_bytes(JSONSerializer()))


### PR DESCRIPTION
* Add test for mismatching url and metadata versions
* simplify test_unsigned_metadata so it is similar to the just added version mismatch test
* Use (simplified version of) the version mismatch test as the example in README
* Also try to make the example otherwise more readable


Fixes #134
Fixes #195 