### PR TITLE
Enable dependabot for the go client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
       update-types:
         - "minor"
         - "patch"
+
+- package-ecosystem: "gomod"
+  directory: "/clients/go-tuf/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
No way to test this but looks like it should work.