### PR TITLE
RepositorySimulator: Switch default keytype back to ecdsa

### DIFF
--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -157,7 +157,7 @@ class RepositorySimulator:
         return signed
 
     def new_signer(
-        self, keytype: str = "rsa", scheme: str = "rsa-pkcs1v15-sha256"
+        self, keytype: str = "ecdsa", scheme: str = "ecdsa-sha2-nistp256"
     ) -> CryptoSigner:
         """Return a Signer (from a set of pre-generated signers)."""
         try:


### PR DESCRIPTION
We made this rsa because the deterministic signatures allowed us to workaround some metadata hashing test issues. Now that we explicitly sign everything, the workarounds are not needed.

Switch back to ecdsa: That seems to be more widely supported (RSA support is patchy because of the historic flip-flopping the spec did between PSS and pkcs1v15).