### PR TITLE
Byte comparison tweaks

### DIFF
--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -120,3 +120,23 @@ class ClientRunner:
             roles.append((rolename, md.signed.version))
 
         return roles
+
+    def assert_metadata(self, role: str, expected_bytes: bytes | None) -> None:
+        """Assert that trusted roles metadata matches the expected bytes
+
+        This assert uses deserialized comparison: See test_metadata_bytes_match
+        for the test that requires byte-for-byte equality.
+        """
+        try:
+            trusted = MetadataTest.from_file(
+                os.path.join(self.metadata_dir, f"{role}.json")
+            )
+        except StorageError:
+            trusted = None
+
+        if expected_bytes is not None:
+            expected = Metadata.from_bytes(expected_bytes)
+        else:
+            expected = None
+
+        assert trusted == expected

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -139,4 +139,4 @@ class ClientRunner:
         else:
             expected = None
 
-        assert trusted == expected
+        assert trusted == expected, f"Unexpected trusted role {role} content"

--- a/tuf_conformance/test_basic.py
+++ b/tuf_conformance/test_basic.py
@@ -9,18 +9,16 @@ from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer
 
 
-def test_basic_init_and_refresh(client: ClientRunner, server: SimulatorServer) -> None:
+def test_basic_refresh_requests(client: ClientRunner, server: SimulatorServer) -> None:
     """Test basic client functionality.
 
-    Run a refresh, verify client trusted metadata and requests made by the client
+    Run a refresh, verify requests made by the client
     """
     init_data, repo = server.new_test(client.test_name)
-    # Run the test: step 1:  initialize client
     assert client.init_client(init_data) == 0
 
-    # Run the test: step 2: Refresh
+    # Run client refresh, verify that expected requests were made
     assert client.refresh(init_data) == 0
-    # Verify that expected requests were made
     assert repo.metadata_statistics == [
         ("root", 2),
         ("timestamp", None),
@@ -28,11 +26,22 @@ def test_basic_init_and_refresh(client: ClientRunner, server: SimulatorServer) -
         ("targets", 1),
     ]
 
-    # verify client metadata looks as expected
-    assert client.version(Root.type) == 1
-    assert client.version(Timestamp.type) == 1
-    assert client.version(Snapshot.type) == 1
-    assert client.version(Targets.type) == 1
+
+def test_basic_refresh_trusted_data(
+    client: ClientRunner, server: SimulatorServer
+) -> None:
+    """Test basic client functionality.
+
+    Run a refresh, verify clients trusted metadata
+    """
+    init_data, repo = server.new_test(client.test_name)
+    assert client.init_client(init_data) == 0
+
+    # Run client refresh, verify that trusted metadata is as expected
+    assert client.refresh(init_data) == 0
+
+    for role in [Root.type, Timestamp.type, Snapshot.type, Targets.type]:
+        client.assert_metadata(role, repo.fetch_metadata(role))
 
 
 def test_implicit_refresh(client: ClientRunner, server: SimulatorServer) -> None:
@@ -45,21 +54,17 @@ def test_implicit_refresh(client: ClientRunner, server: SimulatorServer) -> None
     init_data, repo = server.new_test(client.test_name)
     assert client.init_client(init_data) == 0
 
+    # Run download, verify that requests and trusted metadata are as expected
     assert client.download_target(init_data, "nonexistent artifact") == 1
 
-    # Verify that expected requests were made
     assert repo.metadata_statistics == [
         ("root", 2),
         ("timestamp", None),
         ("snapshot", 1),
         ("targets", 1),
     ]
-
-    # verify client metadata looks as expected
-    assert client.version(Root.type) == 1
-    assert client.version(Timestamp.type) == 1
-    assert client.version(Snapshot.type) == 1
-    assert client.version(Targets.type) == 1
+    for role in [Root.type, Timestamp.type, Snapshot.type, Targets.type]:
+        client.assert_metadata(role, repo.fetch_metadata(role))
 
 
 def test_invalid_initial_root(client: ClientRunner, server: SimulatorServer) -> None:

--- a/tuf_conformance/test_updater_key_rotations.py
+++ b/tuf_conformance/test_updater_key_rotations.py
@@ -1,9 +1,8 @@
-import os
 from dataclasses import dataclass
 
 import pytest
 from securesystemslib.signer import CryptoSigner
-from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
+from tuf.api.metadata import Root, Snapshot, Targets, Timestamp
 
 from tuf_conformance.client_runner import ClientRunner
 from tuf_conformance.simulator_server import SimulatorServer


### PR DESCRIPTION
Fixes #214: This should allow testing clients that use their own serialization format when storing trusted metadata