### PR TITLE
action.yml: remove pip cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,6 @@ runs:
       uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
         python-version: "3.11"
-        cache: "pip"
 
     - name: Install test
       run: |


### PR DESCRIPTION
This does not work if there is no python project checked out in current directory: so the workflow will fail when any non-python project uses the action

Fixes #216 