### PR TITLE
tests: Avoid using non-default keytypes when possible

### DIFF
--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 SPEC_VER = ".".join(SPECIFICATION_VERSION)
 
 # Generate some signers once (to avoid all tests generating them)
-NUM_SIGNERS = 9
+NUM_SIGNERS = 14
 SIGNERS = {
     ("rsa", "rsassa-pss-sha256"): [
         CryptoSigner.generate_rsa() for _ in range(NUM_SIGNERS)

--- a/tuf_conformance/test_updater_key_rotations.py
+++ b/tuf_conformance/test_updater_key_rotations.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 import pytest
-from securesystemslib.signer import CryptoSigner
 from tuf.api.metadata import Root, Snapshot, Targets, Timestamp
 
 from tuf_conformance.client_runner import ClientRunner
@@ -141,14 +140,10 @@ def test_root_rotation(
     standard client update workflow.
     """
 
-    signers = []
-    for _ in range(10):
-        signer = CryptoSigner.generate_ed25519()
-        signers.append(signer)
-
     # initialize a simulator with repository content we need
     init_data, repo = server.new_test(client.test_name)
     del repo.signed_mds[Root.type]
+    signers = [repo.new_signer() for _ in range(10)]
 
     for rootver in root_versions:
         # clear root keys, signers
@@ -196,17 +191,13 @@ def test_non_root_rotations(
     is the expected one after all roots have been loaded from remote using
     the standard client update workflow.
     """
-    signers = []
-    for _ in range(10):
-        signer = CryptoSigner.generate_ed25519()
-        signers.append(signer)
 
     # initialize a simulator with repository content we need
     init_data, repo = server.new_test(client.test_name)
     assert client.init_client(init_data) == 0
+    signers = [repo.new_signer() for _ in range(10)]
 
-    roles = ["timestamp", "snapshot", "targets"]
-    for role in roles:
+    for role in ["timestamp", "snapshot", "targets"]:
         # clear role keys, signers
         repo.root.roles[role].keyids.clear()
         repo.signers[role].clear()


### PR DESCRIPTION
Key rotation tests used ed25519 because non-deterministic keys like ecdsa where an issue (when the test wanted to compare actual metadata json) for RepositorySimulator at the time. This is no longer the case: Use default keytype.

Increase number of generated keys so there is enough for the rotation tests.
