### PR TITLE
Improve assert output on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ fix: env/pyvenv.cfg
 
 PHONY: test-python-tuf
 test-python-tuf: dev
-	./env/bin/pytest tuf_conformance \
+	./env/bin/pytest -v tuf_conformance \
 		--entrypoint "./env/bin/python ./clients/python-tuf/python_tuf.py" \
 		--repository-dump-dir $(DUMP_DIR)
 	@echo Repository dump in $(DUMP_DIR)
@@ -60,7 +60,7 @@ test-python-tuf: dev
 
 PHONY: test-go-tuf
 test-go-tuf: dev build-go-tuf
-	./env/bin/pytest tuf_conformance \
+	./env/bin/pytest -v tuf_conformance \
 		--entrypoint "./clients/go-tuf/go-tuf" \
 		--repository-dump-dir $(DUMP_DIR)
 	@echo Repository dump in $(DUMP_DIR)

--- a/tuf_conformance/__init__.py
+++ b/tuf_conformance/__init__.py
@@ -1,1 +1,6 @@
+import pytest
+
 __version__ = "2.1.0"
+
+# register pytest asserts before the imports happen in conftest.py
+pytest.register_assert_rewrite("tuf_conformance.client_runner")

--- a/tuf_conformance/client_runner.py
+++ b/tuf_conformance/client_runner.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 
 from tuf.api.exceptions import StorageError
 from tuf.api.metadata import Metadata
+from tuf.api.serialization.json import JSONSerializer
 
 from tuf_conformance.metadata import MetadataTest
 from tuf_conformance.simulator_server import (
@@ -130,13 +131,8 @@ class ClientRunner:
         try:
             trusted = MetadataTest.from_file(
                 os.path.join(self.metadata_dir, f"{role}.json")
-            )
+            ).to_bytes(JSONSerializer())
         except StorageError:
             trusted = None
 
-        if expected_bytes is not None:
-            expected = Metadata.from_bytes(expected_bytes)
-        else:
-            expected = None
-
-        assert trusted == expected, f"Unexpected trusted role {role} content"
+        assert trusted == expected_bytes, f"Unexpected trusted role {role} content"


### PR DESCRIPTION
* Failures where the assert happened in Clientrunner.assert_metadata where not handled as pytest verbose asserts: Fix this by registering the module for assert rewriting
* assert on serialized metadata so that pytest assert gives us nice output
* Increase verbosity in Makefile so it's at same level as the action

Fixes #230, mostly