### PR TITLE
clients/go-tuf: Fix module import urls

### DIFF
--- a/clients/go-tuf/go.mod
+++ b/clients/go-tuf/go.mod
@@ -1,4 +1,4 @@
-module github.com/jku/tuf-conformance/clients/go-tuf
+module github.com/theupdateframework/tuf-conformance/clients/go-tuf
 
 go 1.22.5
 

--- a/clients/go-tuf/main.go
+++ b/clients/go-tuf/main.go
@@ -12,9 +12,10 @@
 package main
 
 import (
-	"os"
 	"fmt"
-	tufclient "github.com/jku/tuf-conformance/clients/go-tuf/cmd"
+	"os"
+
+	tufclient "github.com/theupdateframework/tuf-conformance/clients/go-tuf/cmd"
 )
 
 func main() {


### PR DESCRIPTION
The url isn't really used for anything in this case but let's fix it anyway.