### PR TITLE
Prepare 2.2.0 release

### DIFF
--- a/tuf_conformance/__init__.py
+++ b/tuf_conformance/__init__.py
@@ -1,6 +1,6 @@
 import pytest
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 # register pytest asserts before the imports happen in conftest.py
 pytest.register_assert_rewrite("tuf_conformance.client_runner")


### PR DESCRIPTION
This release contains no new tests and test results are not expected to change, except in one case: If `test_root_rotation` or `test_non_root_rotations` are marked as "Expected To Fail" because of the non-default keytype, this expectation can now be removed: these tests now use the default keytype (ecdsa).

* local testing: "make dev" now checks for faketime binary to enable failing early (#240)
* Failure output was improved (#239)
* Tests now use default keytype whenever possible: In `practice test_non_root_rotations()` and `test_root_rotation()` switched from ed25519 to the default ecdsa key (#238)
* Expected failures are now documented better (#233)