### PR TITLE
pyproject: remove unnecessary extra dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tuf-conformance"
 dependencies = [
-    "securesystemslib[crypto, pynacl]==1.2.0" ,
+    "securesystemslib[crypto]==1.2.0",
     "tuf==5.1.0",
     "pytest==8.3.4"
 ]


### PR DESCRIPTION
pynacl is no longer needed by securesystemslib