### PR TITLE
Fix lint warnings, Add some lint rulesets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,8 @@ module = ["securesystemslib.*"]
 ignore_missing_imports = "True"
 
 [tool.ruff]
-lint.select = ["ANN", "E", "F", "I", "N", "PL", "PYI", "RUF", "S", "UP", "W",]
+lint.select = ["ANN", "DTZ", "E", "F", "FA", "I", "N", "PIE", "PL", "PYI", "RET", "RUF", "S", "SIM", "UP", "W",]
 lint.ignore = [
-    "ANN101", "ANN102", # nonsense, deprecated in ruff
     "S101",             # assert is fine in pytest tests
     "PLR2004",          # magic values are ok in a test suite
 ]

--- a/tuf_conformance/repository_simulator.py
+++ b/tuf_conformance/repository_simulator.py
@@ -18,7 +18,7 @@ Example::
     sim = RepositorySimulator()
 
     # publish a new version of metadata
-    sim.root.expires = datetime.datetime.utcnow() + datetime.timedelta(days=7)
+    sim.root.expires = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=7)
     sim.publish([Root.type])
 
     # there are helper functions to do things like adding an artifact
@@ -115,7 +115,7 @@ class RepositorySimulator:
         self.metadata_statistics: list[tuple[str, int | None]] = []
         self.artifact_statistics: list[tuple[str, str | None]] = []
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
         self.safe_expiry = now.replace(microsecond=0) + datetime.timedelta(days=30)
 
         # Make a semi-deep copy of generated signers: The private keys can't be deep
@@ -179,7 +179,7 @@ class RepositorySimulator:
         """remove all keys for role, then add threshold of new keys"""
         self.root.roles[role].keyids.clear()
         self.signers[role].clear()
-        for _ in range(0, self.root.roles[role].threshold):
+        for _ in range(self.root.roles[role].threshold):
             signer = self.new_signer()
             self.root.add_key(signer.public_key, role)
             self.add_signer(role, signer)
@@ -282,7 +282,8 @@ class RepositorySimulator:
 
             self.metadata_statistics.append((role, version))
             return self.fetch_metadata(role, version)
-        elif path.startswith("targets/"):
+
+        if path.startswith("targets/"):
             # figure out target path and hash prefix
             target_path = path[len("targets/") :]
             dir_parts, sep, prefixed_filename = target_path.rpartition("/")
@@ -295,6 +296,7 @@ class RepositorySimulator:
 
             self.artifact_statistics.append((target_path, prefix))
             return self.fetch_target(target_path, prefix)
+
         raise ValueError(f"Unknown path '{path}'")
 
     def fetch_target(self, target_path: str, target_hash: str | None) -> bytes:

--- a/tuf_conformance/simulator_server.py
+++ b/tuf_conformance/simulator_server.py
@@ -47,7 +47,6 @@ class _ReqHandler(BaseHTTPRequestHandler):
 
         Avoid output for now. TODO We may want to log in some situations?
         """
-        pass
 
 
 class SimulatorServer(ThreadingHTTPServer):

--- a/tuf_conformance/test_keys.py
+++ b/tuf_conformance/test_keys.py
@@ -80,7 +80,7 @@ def test_duplicate_keys(client: ClientRunner, server: SimulatorServer) -> None:
     signer = repo.new_signer()
 
     # Add one key 9 times to root
-    for n in range(0, 9):
+    for n in range(9):
         repo.root.add_key(signer.public_key, Snapshot.type)
 
     repo.add_signer(Snapshot.type, signer)
@@ -98,7 +98,7 @@ def test_duplicate_keys(client: ClientRunner, server: SimulatorServer) -> None:
         if sig["keyid"] == signer.public_key.keyid:
             break
     assert sig is not None
-    for n in range(0, 8):
+    for n in range(8):
         md["signatures"].append(sig)
     repo.signed_mds[Snapshot.type].append(json.dumps(md).encode())
 


### PR DESCRIPTION
Main goal here is to silence this warning:
```
warning: The following rules have been removed and ignoring them has no effect:
    - ANN101
    - ANN102
```
This meant just removing them from lint.ignore list.

While I was looking at the lint config, I did add a few lint rulesets that I use elsewhere too (see https://docs.astral.sh/ruff/rules/ for details) . This meant a few minor code tweaks.
