### PR TITLE
test artifact caching

### DIFF
--- a/CLIENT-CLI.md
+++ b/CLIENT-CLI.md
@@ -72,8 +72,12 @@ given targets directory. Client must ensure that metadata is up-to-date before d
 Client must use exit code 0 if the download succeeded fully and exit code 1 if any part of
 the download failed.
 
-Client may use any filename or directory structure it wants within `TARGET_DIR`: The expectation is that if a 
-targetpath is downloaded twice it is stored with the same filename (even if the content changed).
+Client should support artifact caching: if client is requested to download an artifact that has
+already been downloaded (with matching hashes), it should not download the artifact again.
+
+Client may use any filename or directory structure it wants within `TARGET_DIR`: The expectation
+is that if an artifact is downloaded twice (because the artifact content changed) it is stored in
+`TARGET_DIR` with the same filename.
 
 This command may be called multiple times in a test.
 

--- a/clients/python-tuf/python_tuf.py
+++ b/clients/python-tuf/python_tuf.py
@@ -50,7 +50,8 @@ def download_target(
     target_info = updater.get_targetinfo(target_name)
     if not target_info:
         raise RuntimeError(f"{target_name} not found in repository")
-    updater.download_target(target_info)
+    if not updater.find_cached_target(target_info):
+        updater.download_target(target_info)
 
 
 def main() -> int:


### PR DESCRIPTION
Artifact caching is not part of the spec but it is a good idea
* Client CLI document did not mention caching before: Add it in the doc
* Add test that verifies that two download commands do not result in two downloads
* python test client did not support this so support was added

we already have tests for making sure that if artifact content changes the new content is downloaded, so I did not test that here