### PR TITLE
ClientRunner: accept fake time in download_target()

### DIFF
--- a/tuf_conformance/_internal/client_runner.py
+++ b/tuf_conformance/_internal/client_runner.py
@@ -81,10 +81,16 @@ class ClientRunner:
         ]
         return self._run(cmd)
 
-    def download_target(self, data: ClientInitData, target_name: str) -> int:
+    def download_target(
+        self, data: ClientInitData, target_name: str, fake_time: datetime | None = None
+    ) -> int:
         self._server.debug_dump(self.test_name)
+        cmd = self._cmd
+        if fake_time:
+            cmd = ["faketime", f"{fake_time}", *cmd]
+
         cmd = [
-            *self._cmd,
+            *cmd,
             "--metadata-url",
             data.metadata_url,
             "--metadata-dir",

--- a/tuf_conformance/test_static_repositories.py
+++ b/tuf_conformance/test_static_repositories.py
@@ -17,4 +17,4 @@ def test_static_repository(
 
     assert static_client.init_client(init_data) == 0
     assert static_client.refresh(init_data, refresh_time) == 0
-    assert static_client.download_target(init_data, targetpath) == 0
+    assert static_client.download_target(init_data, targetpath, refresh_time) == 0


### PR DESCRIPTION
refresh() already supported setting a fake time, add it to download_target as well.

Use this feature in test_static_repository().

Fixes #269