### PR TITLE
Prepare 2.3 release

### DIFF
--- a/tuf_conformance/__init__.py
+++ b/tuf_conformance/__init__.py
@@ -1,6 +1,6 @@
 import pytest
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 # register pytest asserts before the imports happen in conftest.py
 pytest.register_assert_rewrite("tuf_conformance._internal.client_runner")


### PR DESCRIPTION
There's no pressing need to do a release but it has been almost 3 months so why not.

---

## Changelog

### New tests

* `test_faketime` verifies client is compatible with test suites time faking approach
* `test_static_repository[sigstore-root-signing]`: Sigstore TUF repo added as static test
* `test_artifact_cache`: verifies client caches artifacts. Artifact caching is not required by specification so clients should mark this one expected to fail if they do not support caching

### Internal changes

* Fake time implementation was refactored
* Static test repositories can now set a fake time (to enable testing with a repository with a short expiry)
* All test suite infrastructure code was moved to a sub directory: test code should be easier to browse now