### PR TITLE
test: verify cached roles against each delegator

### DIFF
--- a/CLIENT-CLI.md
+++ b/CLIENT-CLI.md
@@ -63,7 +63,7 @@ Download an artifact from repository, store it in local disk.
 where
 - `METADATA_DIR` is a directory where the client is expected to store metadata it considers valid
 - `METADATA_URL` is a URL to the repository metadata store
-- `TARGET_PATH` is the TUF targetpath of the artifact that should be downloaded
+- `TARGET_PATH` is the TUF targetpath of an artifact that should be downloaded. `--target-name` may be repeated: targets must be processed in argument order using the same client/updater instance, and the command must stop and return exit code 1 if any target fails.
 - `TARGET_URL` is the base URL for repository target store
 - `TARGET_DIR`: is a directory where the client should store downloaded and verified files
 

--- a/clients/go-tuf/cmd/download.go
+++ b/clients/go-tuf/cmd/download.go
@@ -31,11 +31,11 @@ var downloadCmd = &cobra.Command{
 	Short: "Downloads a target file",
 	//Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if FlagMetadataURL == "" || FlagMetadataDir == "" || FlagTargetUrl == "" {
+		if FlagMetadataURL == "" || FlagMetadataDir == "" || len(FlagTargetUrls) == 0 {
 			fmt.Println("Error: required flag(s): \"metadata-url\" or \"metadata-dir\" not set")
 			os.Exit(1)
 		}
-		targetInfoName, err := cmd.Flags().GetString("target-name")
+		targetInfoNames, err := cmd.Flags().GetStringArray("target-name")
 		if err != nil {
 			os.Exit(1)
 		}
@@ -50,7 +50,7 @@ var downloadCmd = &cobra.Command{
 
 		// refresh metadata and try to download the desired target
 		// first arg means the name of the target file to download
-		return RefreshAndDownloadCmd(targetInfoName, targetBaseUrl, targetDownloadDir, false)
+		return RefreshAndDownloadCmd(targetInfoNames, targetBaseUrl, targetDownloadDir, false)
 	},
 }
 
@@ -58,7 +58,7 @@ func init() {
 	rootCmd.AddCommand(downloadCmd)
 }
 
-func RefreshAndDownloadCmd(targetName string,
+func RefreshAndDownloadCmd(targetNames []string,
 	targetBaseUrl string,
 	targetDownloadDir string,
 	refreshOnly bool) error {
@@ -109,38 +109,39 @@ func RefreshAndDownloadCmd(targetName string,
 		return fmt.Errorf("failed to refresh trusted metadata: %w", err)
 	}
 
-	// exit early if it's a refresh only command or there's no targetName provided
-	if refreshOnly || targetName == "" {
+	// exit early if it's a refresh only command or there are no targets provided
+	if refreshOnly || len(targetNames) == 0 {
 		fmt.Println("go-tuf-metadata test client: Refreshed metadata in", FlagMetadataDir)
 		return nil
 	}
 
-	// search if the desired target is available
-	targetInfo, err := up.GetTargetInfo(targetName)
-	if err != nil {
-		return fmt.Errorf("target %s not found: %w", targetName, err)
-	}
+	for _, targetName := range targetNames {
+		// search if the desired target is available
+		targetInfo, err := up.GetTargetInfo(targetName)
+		if err != nil {
+			return fmt.Errorf("target %s not found: %w", targetName, err)
+		}
 
-	// target is available, so let's see if the target is already present locally
-	localPath := filepath.Join(targetDownloadDir, url.QueryEscape(targetName))
-	path, _, err := up.FindCachedTarget(targetInfo, localPath)
-	if err != nil {
-		return fmt.Errorf("failed while finding a cached target: %w", err)
-	}
+		// target is available, so let's see if the target is already present locally
+		localPath := filepath.Join(targetDownloadDir, url.QueryEscape(targetName))
+		path, _, err := up.FindCachedTarget(targetInfo, localPath)
+		if err != nil {
+			return fmt.Errorf("failed while finding a cached target: %w", err)
+		}
 
-	if path != "" {
-		fmt.Printf("Target %s is already present at - %s\n", targetName, path)
-		return nil
-	}
+		if path != "" {
+			fmt.Printf("Target %s is already present at - %s\n", targetName, path)
+			continue
+		}
 
-	// target is not present locally, so let's try to download it
-	//
-	path, _, err = up.DownloadTarget(targetInfo, localPath, targetBaseUrl)
-	if err != nil {
-		return fmt.Errorf("failed to download target file %s - %w", targetName, err)
-	}
+		// target is not present locally, so try to download it
+		path, _, err = up.DownloadTarget(targetInfo, localPath, targetBaseUrl)
+		if err != nil {
+			return fmt.Errorf("failed to download target file %s - %w", targetName, err)
+		}
 
-	fmt.Printf("go-tuf-metadata test client: downloaded target %s in %s\n", targetName, path)
+		fmt.Printf("go-tuf-metadata test client: downloaded target %s in %s\n", targetName, path)
+	}
 
 	return nil
 }

--- a/clients/go-tuf/cmd/refresh.go
+++ b/clients/go-tuf/cmd/refresh.go
@@ -28,7 +28,7 @@ var refreshCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		// do a refresh only
-		return RefreshAndDownloadCmd("", "", "", true)
+		return RefreshAndDownloadCmd(nil, "", "", true)
 	},
 }
 

--- a/clients/go-tuf/cmd/root.go
+++ b/clients/go-tuf/cmd/root.go
@@ -22,7 +22,7 @@ var FlagVerbosity bool
 var FlagMetadataURL string
 var FlagMetadataDir string
 var FlagTargetDir string
-var FlagTargetUrl string
+var FlagTargetUrls []string
 var FlagTargetBaseUrl string
 var FlagDaysInFuture string
 var MaxRootRotations int
@@ -44,7 +44,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&FlagMetadataURL, "metadata-url", "", "URL of the TUF repository")
 	rootCmd.PersistentFlags().StringVar(&FlagMetadataDir, "metadata-dir", "", "directory to save metadata")
 	rootCmd.PersistentFlags().StringVar(&FlagTargetDir, "target-dir", "", "directory to save target files")
-	rootCmd.PersistentFlags().StringVar(&FlagTargetUrl, "target-name", "", "name of target file from the targets.json metadata")
+	rootCmd.PersistentFlags().StringArrayVar(&FlagTargetUrls, "target-name", nil, "name of target file from the targets.json metadata (repeatable)")
 	rootCmd.PersistentFlags().StringVar(&FlagTargetBaseUrl, "target-base-url", "", "base url for target file")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/clients/go-tuf/go-tuf.xfails
+++ b/clients/go-tuf/go-tuf.xfails
@@ -1,4 +1,5 @@
 # Add test names here to mark them "expected to fail"
 
-# Example: (commented out since the XFAIL is not needed with current go-tuf)
-# test_keytype_and_scheme[rsa/rsassa-pss-sha256]
+# go-tuf caches delegated metadata by role name without re-verifying it
+# against the delegator used by a later target lookup.
+test_cached_role_is_verified_against_current_delegator

--- a/clients/python-tuf/python_tuf.py
+++ b/clients/python-tuf/python_tuf.py
@@ -36,7 +36,7 @@ def refresh(metadata_url: str, metadata_dir: str) -> None:
 def download_target(
     metadata_url: str,
     metadata_dir: str,
-    target_name: str,
+    target_names: list[str],
     download_dir: str,
     target_base_url: str,
 ) -> None:
@@ -49,11 +49,12 @@ def download_target(
         target_base_url,
         bootstrap=None,
     )
-    target_info = updater.get_targetinfo(target_name)
-    if not target_info:
-        raise RuntimeError(f"{target_name} not found in repository")
-    if not updater.find_cached_target(target_info):
-        updater.download_target(target_info)
+    for target_name in target_names:
+        target_info = updater.get_targetinfo(target_name)
+        if not target_info:
+            raise RuntimeError(f"{target_name} not found in repository")
+        if not updater.find_cached_target(target_info):
+            updater.download_target(target_info)
 
 
 def main() -> int:
@@ -62,7 +63,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="TUF Client Example")
     parser.add_argument("--metadata-url", required=False)
     parser.add_argument("--metadata-dir", required=True)
-    parser.add_argument("--target-name", required=False)
+    parser.add_argument("--target-name", action="append", required=False)
     parser.add_argument("--target-dir", required=False)
     parser.add_argument("--target-base-url", required=False)
     parser.add_argument("-v", "--verbose", action="count", default=0)

--- a/clients/python-tuf/python_tuf.py.xfails
+++ b/clients/python-tuf/python_tuf.py.xfails
@@ -1,0 +1,3 @@
+# python-tuf caches delegated metadata by role name without re-verifying it
+# against the delegator used by a later target lookup.
+test_cached_role_is_verified_against_current_delegator

--- a/tuf_conformance/_internal/client_runner.py
+++ b/tuf_conformance/_internal/client_runner.py
@@ -84,19 +84,28 @@ class ClientRunner:
     def download_target(
         self, data: ClientInitData, target_name: str, fake_time: datetime | None = None
     ) -> int:
+        return self.download_targets(data, [target_name], fake_time)
+
+    def download_targets(
+        self,
+        data: ClientInitData,
+        target_names: list[str],
+        fake_time: datetime | None = None,
+    ) -> int:
+        """Download targets in order using a single client invocation."""
         self._server.debug_dump(self.test_name)
         cmd = self._cmd
         if fake_time:
             cmd = ["faketime", f"{fake_time}", *cmd]
 
+        target_args = [arg for name in target_names for arg in ("--target-name", name)]
         cmd = [
             *cmd,
             "--metadata-url",
             data.metadata_url,
             "--metadata-dir",
             self.metadata_dir,
-            "--target-name",
-            target_name,
+            *target_args,
             "--target-dir",
             self.artifact_dir,
             "--target-base-url",

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -282,6 +282,72 @@ def test_targetfile_search(
     assert repo.metadata_statistics[4:] == exp_calls
 
 
+def test_cached_role_is_verified_against_current_delegator(
+    client: ClientRunner, server: SimulatorServer
+) -> None:
+    """A cached role must not inherit authority from an earlier search path."""
+    init_data, repo = server.new_test(client.test_name)
+    assert client.init_client(init_data) == 0
+
+    # Two top-level branches authorize the same role name for disjoint paths.
+    repo.add_delegation(
+        Targets.type,
+        DelegatedRole("parent-a", [], 1, False, ["team-a/*"]),
+        Targets(expires=repo.safe_expiry),
+    )
+    repo.add_delegation(
+        Targets.type,
+        DelegatedRole("parent-b", [], 1, False, ["team-b/*"]),
+        Targets(expires=repo.safe_expiry),
+    )
+    release = Targets(expires=repo.safe_expiry)
+    repo.add_delegation(
+        "parent-a",
+        DelegatedRole("release", [], 1, False, ["team-a/*"]),
+        release,
+    )
+    repo.add_delegation(
+        "parent-b",
+        DelegatedRole("release", [], 1, False, ["team-b/*"]),
+        release,
+    )
+
+    # add_delegation() created a distinct release key for each parent. Publish
+    # release metadata with only parent A's signer: it is valid through A but
+    # must fail verification when a later lookup reaches it through B.
+    parent_b = repo.any_targets("parent-b")
+    assert parent_b.delegations is not None
+    assert parent_b.delegations.roles is not None
+    parent_b_keyids = parent_b.delegations.roles["release"].keyids
+    assert len(parent_b_keyids) == 1
+    del repo.signers["release"][parent_b_keyids[0]]
+
+    repo.add_artifact("release", b"trusted A", "team-a/trusted_root.json")
+    repo.add_artifact("release", b"malicious B", "team-b/trusted_root.json")
+    repo.publish(
+        [
+            "release",
+            "parent-a",
+            "parent-b",
+            Targets.type,
+            Snapshot.type,
+            Timestamp.type,
+        ]
+    )
+
+    # Both lookups happen in one process with one updater. The first target is
+    # valid and gets downloaded; the second must fail instead of reusing the
+    # role cached under parent A's authority.
+    assert (
+        client.download_targets(
+            init_data,
+            ["team-a/trusted_root.json", "team-b/trusted_root.json"],
+        )
+        == 1
+    )
+    assert client.get_downloaded_target_bytes() == [b"trusted A"]
+
+
 def test_delegation_not_in_snapshot(
     client: ClientRunner, server: SimulatorServer
 ) -> None:

--- a/tuf_conformance/test_updater_delegation_graphs.py
+++ b/tuf_conformance/test_updater_delegation_graphs.py
@@ -285,7 +285,16 @@ def test_targetfile_search(
 def test_cached_role_is_verified_against_current_delegator(
     client: ClientRunner, server: SimulatorServer
 ) -> None:
-    """A cached role must not inherit authority from an earlier search path."""
+    """A cached role must not inherit authority from an earlier search path.
+
+    The test creates a "diamond shape" delegation where a role is delegated to
+    from multiple delegators. Client should not skip validating the current
+    delegation path just because another path to this role has already been
+    validated.
+
+    Refusing to to operate with "diamond shape" delegations is also considered
+    acceptable (as it's not clear that this structure has any real use cases).
+    """
     init_data, repo = server.new_test(client.test_name)
     assert client.init_client(init_data) == 0
 
@@ -335,9 +344,11 @@ def test_cached_role_is_verified_against_current_delegator(
         ]
     )
 
-    # Both lookups happen in one process with one updater. The first target is
-    # valid and gets downloaded; the second must fail instead of reusing the
-    # role cached under parent A's authority.
+    # Make two lookups in one updater process. The first targets delegation is
+    # valid but second ones delegation is not.
+    # There are two accepted client choices:
+    # 1. first target is downloaded, second is not
+    # 2. Nothing is downloaded (multiple delegators for a role are not accepted)
     assert (
         client.download_targets(
             init_data,
@@ -345,7 +356,7 @@ def test_cached_role_is_verified_against_current_delegator(
         )
         == 1
     )
-    assert client.get_downloaded_target_bytes() == [b"trusted A"]
+    assert client.get_downloaded_target_bytes() in ([b"trusted A"], [])
 
 
 def test_delegation_not_in_snapshot(


### PR DESCRIPTION
## Summary

- make `--target-name` repeatable so conformance tests can perform multiple target lookups with one updater instance
- add a delegation graph where two parents authorize the same role name with different keys
- verify metadata cached through parent A is rejected when a later lookup reaches that role through parent B
- update the bundled Python and Go adapters for multi-target invocations
- mark the new test as an expected failure for python-tuf and go-tuf, which currently exhibit the vulnerable cache behavior

A single target lookup cannot exercise this condition: the first lookup must populate the in-memory delegated-role cache and the second must reach that role through a different delegating edge.

## Validation

- `make lint`
- `CGO_ENABLED=0 go test ./...` in `clients/go-tuf`
- new test passes against the patched `sigstore-tuf` conformance adapter
- new test is confirmed to fail, and is marked xfail, against current python-tuf and go-tuf
- all non-faketime Go conformance tests pass locally (107 passed, 1 expected failure); faketime is unavailable in the local environment